### PR TITLE
Packages should not be transitive

### DIFF
--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -12,7 +12,6 @@
 
     <PackageFile Include="$(MSBuildThisFileDirectory)_._" PackagePath="lib/netstandard2.0/_._" />
     <PackageFile Include="*.props;*.targets" PackagePath="build\$(TargetFramework)\%(Filename)%(Extension)" />
-    <PackageFile Include="*.props;*.targets" PackagePath="buildTransitive\$(TargetFramework)\%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Since the generated code is typically internal only, it doesn't make a lot of sense to
make the packages transitive (via the buildTransitive targets) to referencing projects.

The decision on whether a specific project needs its own ThisAssembly or not
should be on the consumer.

This also removes the error where the referenced project that uses these packages
also has an InternalsVisibleTo to the referencing project ,which would then cause
an ambiguous reference to ThisAssembly since it lives in two places with the exact
same name.

Fixes #86