### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - code-of-conduct.md
       - security.md
       - support.md
+      - readme.md
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -34,7 +35,7 @@ jobs:
       - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.102'
+          dotnet-version: '6.0.x'
 
       - name: ✓ ensure format
         run: dotnet format --verify-no-changes -v:diag --exclude ~/.nuget
@@ -55,8 +56,9 @@ jobs:
 
       - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
+        if: matrix.os != 'windows-latest'
         with:
-          dotnet-version: '6.0.101'
+          dotnet-version: '6.0.x'
 
       - name: 🙏 build
         run: dotnet build -m:1 -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,16 +24,10 @@ jobs:
       - name: ⚙ dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.101'
+          dotnet-version: '6.0.x'
 
       - name: 🙏 build
         run: dotnet build -m:1 -p:version=${GITHUB_REF#refs/*/v}
-
-      - name: ⚙ GNU grep
-        if: matrix.os == 'macOS-latest'
-        run: |
-          brew install grep
-          echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> .bash_profile
 
       - name: 🧪 test
         uses: ./.github/workflows/test

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ TestResults
 *.nupkg
 *.metaproj
 *.tmp
+*.log
 *.cache
 *.binlog
 *.zip

--- a/.netconfig
+++ b/.netconfig
@@ -38,14 +38,14 @@
 	sha = 0683ee777d7d878d4bf013d7deea352685135a05
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	etag = 6b9139f22428851c8d7329973f3d92802d25e70a5e0c1b24604c23db991ac8e2
+	etag = 4e65025ab77d15766520234d3a9953ff4f1eea91620e1080f10909de19804877
 	weak
-	sha = bbf637b2a565073a89783c9eb4ebd9c460823fe4
+	sha = e19ed3228a0ac7f64a43197241a788fb224a683f
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	etag = 2b49512f81b6cb44c4ee398975c0edf41bfa4137857b59770805fa7c5e49e94b
+	etag = 1c1705a3f0ed65e33c9133996ebaa100aa445a8b968b2904ad48fef938702006
 	weak
-	sha = 978c71c6afd095eaba35097fd7deed44fa09aa91
+	sha = c78868eba59a3e04602434684f9eac241fef13fb
 [file "license.txt"]
 	url = https://github.com/devlooped/oss/blob/main/license.txt
 	etag = 2c6335b37e4ae05eea7c01f5d0c9d82b49c488f868a8b5ba7bff7c6ff01f3994
@@ -123,9 +123,9 @@
 	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
-	etag = 242bd273906e0cbef773b5a0696f6dccf304d044a659b68e75ede5b1f5ea94fe
+	etag = 1d6a05b7f684b4fc1bb387750b0e100406e8a0017981c4e9d39a012479f35266
 	weak
-	sha = 7ebebbdbab67d9d895a29b3d2b3f82a62a7d8c4e
+	sha = 0e5a33cc685fa85e3a81b797202f3e14e1cd84a9
 [file ".github/workflows/release-artifacts.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/release-artifacts.yml
 	etag = a22b19d3d694b2c6613ce01903a54df9324fecf62558958e677bb4d60f3a6ba4
@@ -153,8 +153,8 @@
 	weak
 [file "src/nuget.config"]
 	url = https://github.com/devlooped/oss/blob/main/src/nuget.config
-	sha = 7d0ccab53c166b87b971040f25de06570821f8ac
-	etag = 0ef58051c4db505e16b39954b27ab9e7a903647998b959e0924634d5f01824dd
+	sha = f86b51943f609f1c8bd3c692826fd937167ce0fb
+	etag = 3e536371c7a2c7866fbf1dbc878929cd78cafb7646f569c20dc6ba03b6a1685b
 	weak
 [file ".github/workflows/pages.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/pages.yml

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <config>
-      <add key="signatureValidationMode" value="accept" />
-    </config>
-    <trustedSigners>
-      <author name="Microsoft">
-        <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
-        <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
-      </author>
-      <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
-        <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
-        <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
-        <certificate fingerprint=" CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
-        <certificate fingerprint="C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
-      </repository>
-    </trustedSigners>
+  <config>
+    <add key="signatureValidationMode" value="accept" />
+  </config>
+  <trustedSigners>
+    <author name="Microsoft">
+      <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+    </author>
+    <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
+      <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      <certificate fingerprint=" CF7AC17AD047ECD5FDC36822031B12D4EF078B6F2B4C5E6BA41F8FF2CF4BAD67" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+      <certificate fingerprint="C474CE76007D02394E0DA5E4DE7C14C680F9E282013CFEF653EF5DB71FDF61F8" hashAlgorithm="SHA256" allowUntrustedRoot="true" />
+    </repository>
+  </trustedSigners>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
# devlooped/oss

- Ignore changes to readme.md as build trigger https://github.com/devlooped/oss/commit/e19ed32
- Remove GNU grep step from publish since it runs ubuntu https://github.com/devlooped/oss/commit/0e5a33c
- Ignore *.log files https://github.com/devlooped/oss/commit/c78868e
- Add default package source mapping for central package versions https://github.com/devlooped/oss/commit/7481dc0
- Fix nuget.config formatting https://github.com/devlooped/oss/commit/f86b519