### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -87,3 +87,6 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+# xUnit1013: Public method should be marked as test. Allows using records as test classes
+dotnet_diagnostic.xUnit1013.severity = none

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,21 +1,19 @@
 ﻿name: changelog
 on:
+  workflow_dispatch:
   release:
     types: [released]
-  workflow_dispatch:
-
-env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: 🔍 GH_TOKEN
-        if: env.GH_TOKEN == ''
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
+      - name: 🤖 defaults
+        uses: devlooped/actions-bot@v1
+        with:
+          name: ${{ secrets.BOT_NAME }}
+          email: ${{ secrets.BOT_EMAIL }}
+          gh_token: ${{ secrets.GH_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v2
@@ -23,7 +21,7 @@ jobs:
           fetch-depth: 0
           ref: main
           token: ${{ env.GH_TOKEN }}
-
+          
       - name: ⚙ ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -32,11 +30,9 @@ jobs:
       - name: ⚙ changelog
         run: |
           gem install github_changelog_generator 
-          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token ${{ secrets.GITHUB_TOKEN }} --o changelog.md --config-file .github/.github_changelog_generator
+          github_changelog_generator --user ${GITHUB_REPOSITORY%/*} --project ${GITHUB_REPOSITORY##*/} --token $GH_TOKEN --o changelog.md --config-file .github/.github_changelog_generator
 
       - name: 🚀 changelog
         run: |
-          git config --local user.name github-actions
-          git config --local user.email github-actions@github.com
           git add changelog.md
           (git commit -m "🖉 Update changelog with ${GITHUB_REF#refs/*/}" && git push) || echo "Done"

--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -1,4 +1,4 @@
-﻿# Synchronizes .netconfig-configured files with dotnet-file
+# Synchronizes .netconfig-configured files with dotnet-file
 name: dotnet-file
 on:
   workflow_dispatch:
@@ -9,18 +9,17 @@ on:
 
 env:
   DOTNET_NOLOGO: true
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
   sync:
     runs-on: windows-latest
     steps:
-      - name: 🔍 GH_TOKEN
-        if: env.GH_TOKEN == ''
-        shell: bash
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "GH_TOKEN=${GITHUB_TOKEN}" >> $GITHUB_ENV
+      - name: 🤖 defaults
+        uses: devlooped/actions-bot@v1
+        with:
+          name: ${{ secrets.BOT_NAME }}
+          email: ${{ secrets.BOT_EMAIL }}
+          gh_token: ${{ secrets.GH_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v2
@@ -29,7 +28,24 @@ jobs:
           ref: main
           token: ${{ env.GH_TOKEN }}
 
+      - name: ⌛ rate
+        shell: pwsh
+        run: |
+          # add random sleep since we run on fixed schedule
+          sleep (get-random -max 60)
+          # get currently authenticated user rate limit info
+          $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
+          # if we don't have at least 100 requests left, wait until reset
+          if ($rate.remaining -lt 10) {
+              $wait = ($rate.reset - (Get-Date (Get-Date).ToUniversalTime() -UFormat %s))
+              echo "Rate limit remaining is $($rate.remaining), waiting for $($wait / 1000) seconds to reset"
+              sleep $wait
+              $rate = gh api rate_limit | convertfrom-json | select -expandproperty rate
+              echo "Rate limit has reset to $($rate.remaining) requests"
+          }
+
       - name: 🔄 sync
+        shell: pwsh
         run: |
           dotnet tool update -g dotnet-gcm
           dotnet gcm store --protocol=https --host=github.com --username=$env:GITHUB_ACTOR --password=$env:GH_TOKEN
@@ -53,9 +69,11 @@ jobs:
           branch: dotnet-file-sync
           delete-branch: true
           labels: dependencies
+          author: ${{ env.BOT_AUTHOR }}
+          committer: ${{ env.BOT_AUTHOR }}
           commit-message: ⬆️ Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
-          title: "Bump files with dotnet-file sync"
+          title: "⬆️ Bump files with dotnet-file sync"
           body: ${{ env.CHANGES }}
           token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -1,0 +1,41 @@
+name: +Mᐁ includes
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**.md'    
+
+jobs:
+  includes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🤖 defaults
+        uses: devlooped/actions-bot@v1
+        with:
+          name: ${{ secrets.BOT_NAME }}
+          email: ${{ secrets.BOT_EMAIL }}
+          gh_token: ${{ secrets.GH_TOKEN }}
+
+      - name: 🤘 checkout
+        uses: actions/checkout@v2
+        with: 
+          token: ${{ env.GH_TOKEN }}
+
+      - name: +Mᐁ includes
+        uses: devlooped/actions-include@v1
+
+      - name: ✍ pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          branch: markdown-includes
+          delete-branch: true
+          labels: docs
+          author: ${{ env.BOT_AUTHOR }}
+          committer: ${{ env.BOT_AUTHOR }}
+          commit-message: +Mᐁ includes
+          title: +Mᐁ includes
+          body: +Mᐁ includes
+          token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: 🔽 gh 
         run: |
-          iwr -useb get.scoop.sh | iex
+          iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
           scoop install gh
 
       - name: 💛 sponsors

--- a/.netconfig
+++ b/.netconfig
@@ -13,9 +13,9 @@
 	weak
 [file ".editorconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.editorconfig
-	etag = 985aa022503959d35b03c870f07ae604cead7580d260775235ef6665aa9a6cbe
+	etag = 4e857df48d0abd81512350d6b3b1a1c83b78284be65bd5172a4ec8e52cd04e2d
 	weak
-	sha = 0683ee777d7d878d4bf013d7deea352685135a05
+	sha = 369cd2bd49ce032f616a2fcb4c997535dbe8d9aa
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
 	etag = 7acb32f5fa6d4ccd9c824605a7c2b8538497f0068c165567807d393dcf4d6bb7
@@ -63,9 +63,9 @@
 	sha = 2fea462dc563923800a7efad24a52aa0541a8864
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	etag = 816dff7cb821a885da46ad200f9b8bea3438d74da3172bc43716d5670abaee6c
+	etag = 852b16129d2c681ad6ec86ff56b256541e0ce0961eb3a9492e0ead89ffe5a6bd
 	weak
-	sha = 024f73321ffe4e927151ff94666c52c2d425139a
+	sha = b9fb0a7d34d6c16fb404f9dff4aac6789ef08a00
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
 	etag = b8d789b5b6bea017cdcc8badcea888ad78de3e34298efca922054e9fb0e7b6b9
@@ -78,9 +78,9 @@
 	sha = f72699c9d52f02e6a3411ef589f2a02007c5e5af
 [file ".netconfig"]
 	url = https://github.com/devlooped/oss/blob/main/.netconfig
-	etag = 8a099aba5d184f06c100e96da1f81df591e2d6418cb347f71ef232eaba60efc3
+	etag = 9790429fec915e75fe3c7e3cea9388a666bbfaaf2c2da66fa3a266b0ca06d97a
 	weak
-	sha = 1f4d8ed2b3b314fd6177c6a0bb1a8c5c6be10044
+	sha = c6f999bdd20b4261b92eec2f4a0fd718ac055848
 [file "Directory.Build.rsp"]
 	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
 	etag = 6a6c6e1d3895df953abf14c82b0899e3eea75cdcd679f6212dcfea15183d73d6
@@ -116,9 +116,9 @@
 	sha = a0f58a6d63e48ae6e55944c556d0bc94476dc8df
 [file ".github/workflows/changelog.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.yml
-	etag = 202803313c2792cb09d9cb8041fe4b39e550e26c90971a57b92534c599a596a7
+	etag = be8306e21620c4e829f2ad67fd1d4c25d484179028301488e9f49b5007e27e02
 	weak
-	sha = be8f625e4cf5c2c572c7e56ba6dc4c4935ab0c00
+	sha = b9671b9e7f6235afbd8551dfedc1ab68a1a95c56
 [file ".github/workflows/publish.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/publish.yml
 	etag = 1d6a05b7f684b4fc1bb387750b0e100406e8a0017981c4e9d39a012479f35266
@@ -141,8 +141,8 @@
 	weak
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 2a39a426f66402e47c80818f92748a1bfd7d736c
-	etag = c424e4f9159bd5d4ccb3b65646a65eed5ad153f57111e3b56900ebce10194f3f
+	sha = b9671b9e7f6235afbd8551dfedc1ab68a1a95c56
+	etag = 9f51b58651ad4e5bbd564475335aed876ec63f9e4d603d29862eb241ba3b7b0f
 	weak
 [file ".github/workflows/test/action.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/test/action.yml
@@ -166,11 +166,21 @@
 	weak
 [file ".github/workflows/sponsors.yml"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.yml
-	sha = 514760df24bd906b9e5d3a56deac0d18cba59a6d
-	etag = 0236ed96c1d11f69b26ac0e039e74107df5731574236e2de2a83152fee5df0a6
+	sha = 8b6384e91fdfcf8f3cc9b3b262a9ca2a1095d06a
+	etag = 2c05a753600913f546c37a2ea9393b3ede3b6f8473e5c2d53462aa7342af7078
 	weak
 [file "Gemfile"]
 	url = https://github.com/devlooped/.github/blob/main/Gemfile
 	sha = f2dc1370469bec1b2d32d82faf659b050cdc7e2a
 	etag = d45832acd078778ffebf260000f6d25172a131f51684744d7e982da2a47170ce
+	weak
+[file ".github/workflows/includes.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
+	sha = b9671b9e7f6235afbd8551dfedc1ab68a1a95c56
+	etag = 91c56f1354273c97e52d1756ebc94fa100045500199c87a3a53e708874a330c7
+	weak
+[file "docs/footer.md"]
+	url = https://github.com/devlooped/oss/blob/main/docs/footer.md
+	sha = 06e7171fa1d1f49300278ebf11020b8d03ef44ac
+	etag = 2e47c8bba7ea60a722ce2bfc8a0222e27bc33f25073486523710383540dc6257
 	weak

--- a/docs/footer.md
+++ b/docs/footer.md
@@ -1,0 +1,8 @@
+# Sponsors 
+
+<!-- include sponsors.md -->
+
+[![Sponsor this project](https://raw.githubusercontent.com/devlooped/sponsors/main/sponsor.png "Sponsor this project")](https://github.com/sponsors/devlooped)
+&nbsp;
+
+[Learn more about GitHub Sponsors](https://github.com/sponsors)

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -145,7 +145,6 @@
 
   </Target>
 
-  <!-- Always append the link to the direct source tree for the current build -->
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
           DependsOnTargets="EnsureProjectInformation"
@@ -153,10 +152,6 @@
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
       <PackageProjectUrl Condition="'$(PackageProjectUrl)' == '' and '$(PublishRepositoryUrl)' == 'true'">$(RepositoryUrl)</PackageProjectUrl>
-      <Description Condition="'$(RepositorySha)' != '' and '$(RepositoryUrl)' != ''">$(Description)
-
-Built from $(RepositoryUrl)/tree/$(RepositorySha)
-      </Description>
       <PackageDescription>$(Description)</PackageDescription>
       <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl)/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>


### PR DESCRIPTION
# devlooped/oss

- Update to public bot defaults action https://github.com/devlooped/oss/commit/b9671b9
- Remove extra paragraph before sponsor button https://github.com/devlooped/oss/commit/06e7171
- Reference sponsors.md directly from upstream https://github.com/devlooped/oss/commit/c6f999b
- Use BOT_ defaults consistently https://github.com/devlooped/oss/commit/98919f7
- Use simple bash variable expansion https://github.com/devlooped/oss/commit/acedd1d
- Ensure checkout before defaults https://github.com/devlooped/oss/commit/721ee85
- Rework to pass secrets explicitly https://github.com/devlooped/oss/commit/15e9486
- Add rate limiting fix https://github.com/devlooped/oss/commit/ef47d78
- Use bot account for sync commit author https://github.com/devlooped/oss/commit/1d3a2f4
- Ensure both author and committer match https://github.com/devlooped/oss/commit/d94ddb1
- Ignore xUnit1013 so records can be used as test classes https://github.com/devlooped/oss/commit/369cd2b
- Remove the source link in the package description https://github.com/devlooped/oss/commit/b9fb0a7

# devlooped/.github

- Fix for installing gh as admin https://github.com/devlooped/.github/commit/8b6384e