### PR TITLE
Improve support for invalid identifier characters

### DIFF
--- a/src/ThisAssembly.Strings/CSharp.sbntxt
+++ b/src/ThisAssembly.Strings/CSharp.sbntxt
@@ -18,27 +18,27 @@
 	    /// </summary>
 {{ end }}
 {{ func render }}
-    public static partial class {{ $0.Name }}
+    public static partial class {{ $0.Id }}
     {
         {{~ for value in $0.Values ~}}
 		{{~ if!(value.HasFormat) ~}}
         {{- summary value ~}}
-	    public static string {{ value.Name }} => Strings.GetResourceManager("{{ $1 }}").GetString("{{ $0.Prefix + value.Name }}");
+	    public static string {{ value.Id }} => Strings.GetResourceManager("{{ $1 }}").GetString("{{ value.Name }}");
         {{~ else ~}}
         {{~ if value.IsIndexedFormat ~}}
         {{- summary value ~}}
-	    public static string {{ value.Name }}(
+	    public static string {{ value.Id }}(
             {{- for arg in value.Format -}}
             object arg{{~ arg ~}}{{ if !for.last }}, {{ end }}
             {{- end -}}) 
             => string.Format(
                 CultureInfo.CurrentCulture,
-                Strings.GetResourceManager("{{ $1 }}").GetString("{{ $0.Prefix + value.Name }}"),
+                Strings.GetResourceManager("{{ $1 }}").GetString("{{ value.Name }}"),
                 {{ for arg in value.Format -}}
                 arg{{- arg -}}{{- if !for.last -}}, {{ end }}{{- end -}});
         {{~ else if value.IsNamedFormat ~}}
         {{- summary value ~}}
-	    public static string {{ value.Name }}(
+	    public static string {{ value.Id }}(
             {{- for arg in value.Format -}}
             object {{ arg ~}}{{ if !for.last }}, {{ end }}
             {{- end -}}) 
@@ -46,7 +46,7 @@
                 CultureInfo.CurrentCulture,
                 Strings
                     .GetResourceManager("{{ $1 }}")
-                    .GetString("{{ $0.Prefix + value.Name }}")
+                    .GetString("{{ value.Name }}")
                     {{- for arg in value.Format }}
                     .Replace("{%{{}%}{{ arg }}{%{}}%}", "{%{{}%}{{ for.index }}{%{}}%}"){{- end -}},
                 {{ for arg in value.Format -}}

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -43,5 +43,5 @@ such as "Hello {name}".
   <ItemGroup>
     <EmbeddedResource Include="ThisAssembly.Strings.cs" />
   </ItemGroup>
-
+  
 </Project>

--- a/src/ThisAssembly.Tests/Resources.resx
+++ b/src/ThisAssembly.Tests/Resources.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Foo_Bar_Baz" xml:space="preserve">
+  <data name="Foo:Bar&gt;Baz" xml:space="preserve">
     <value>Value</value>
   </data>
   <data name="Foo_Hey" xml:space="preserve">

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -6,16 +6,20 @@ namespace ThisAssemblyTests
     public class Tests
     {
         [Fact]
+        public void CanReadResourceFile()
+            => Assert.NotNull(ResourceFile.Load("Resources.resx", "Strings"));
+
+        [Fact]
         public void CanUseConstants()
             => Assert.Equal("Baz", ThisAssembly.Constants.Foo.Bar);
 
         [Fact]
         public void CanUseFileConstants()
-            => Assert.Equal(Path.Combine("Content", "Docs", "License.md"), ThisAssembly.Constants.Content.Docs.License);
+            => Assert.Equal(ThisAssembly.Constants.Content.Docs.License, Path.Combine("Content", "Docs", "License.md"));
 
         [Fact]
         public void CanUseFileConstantLinkedFile()
-            => Assert.Equal(Path.Combine("Included", "Readme.txt"), ThisAssembly.Constants.Included.Readme);
+            => Assert.Equal(ThisAssembly.Constants.Included.Readme, Path.Combine("Included", "Readme.txt"));
 
         [Fact]
         public void CanUseMetadata()

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -54,6 +54,10 @@
     </FileConstant>
     <AssemblyMetadata Include="Foo" Value="Bar" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ThisAssembly.Strings\Model.cs" Link="Model.cs" />
+  </ItemGroup>
   
   <Target Name="GetDependencyTargetPaths" Returns="@(TargetPathWithTargetPlatformMoniker)">
     <ItemGroup>


### PR DESCRIPTION
This brings parity with the built-in resource generator, which properly converts |, :, ;, < and > to underscores in the generated member names.

Fixes #125