### PR TITLE
Fix logic for determining default text resources

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -6,6 +6,7 @@
     <PackOnBuild>true</PackOnBuild>
     <PackFolder>analyzers/dotnet/cs</PackFolder>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <RestoreSources>https://api.nuget.org/v3/index.json</RestoreSources>
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\nugetizer\bin'));$(RestoreSources)</RestoreSources>
 
     <PackageProjectUrl>https://clarius.org/ThisAssembly</PackageProjectUrl>

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.props
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <EmbeddedResourceStringExtensions>.txt;.cs;.sql;.json;.md;</EmbeddedResourceStringExtensions>
+    <EmbeddedResourceStringExtensions>.txt|.cs|.sql|.json|.md;</EmbeddedResourceStringExtensions>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We cannot use semicolons for properties passed to analyzers, we always lose all items except for the first one.

So we switch to a pipe instead. The existing logic was also not accurate since it should consider file extensions, not file name.