### PR TITLE
Fix ThisAssembly.Resources assembly name for analyzer

### DIFF
--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -5,6 +5,9 @@
     <LangVersion>latest</LangVersion>
     <IsRoslynComponent>true</IsRoslynComponent>
     <Nullable>enable</Nullable>
+    <!-- We cannot use ThisAssembly.Resources as the assembly name, or for whatever 
+         reason, it's never added as an analyzer :/ -->
+    <AssemblyName>ThisAssembly.Resource</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
If the analyzer is named as ThisAssembly.Resources.dll, the dotnet SDK just skips the entire assembly. If we rename it, it gets added as expected.