### PR TITLE
Improve Path Sanitization

### DIFF
--- a/src/PathSanitizer.cs
+++ b/src/PathSanitizer.cs
@@ -3,10 +3,10 @@
 static class PathSanitizer
 {
     static readonly Regex invalidCharsRegex = new(@"\W");
-    public static string Sanitize(string path)
+    public static string Sanitize(string path, string parent)
     {
         var partStr = invalidCharsRegex.Replace(path, "_");
-        if (char.IsDigit(partStr[0]))
+        if (char.IsDigit(partStr[0]) || partStr == parent)
             partStr = "_" + partStr;
         return partStr;
     }

--- a/src/PathSanitizer.cs
+++ b/src/PathSanitizer.cs
@@ -6,7 +6,9 @@ static class PathSanitizer
     public static string Sanitize(string path, string parent)
     {
         var partStr = invalidCharsRegex.Replace(path, "_");
-        if (char.IsDigit(partStr[0]) || partStr == parent)
+        if (char.IsDigit(partStr[0]))
+            partStr = "_" + partStr;
+        if (partStr == parent)
             partStr = "_" + partStr;
         return partStr;
     }

--- a/src/PathSanitizer.cs
+++ b/src/PathSanitizer.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.RegularExpressions;
+
+static class PathSanitizer
+{
+    static readonly Regex invalidCharsRegex = new(@"\W");
+    public static string Sanitize(string path)
+    {
+        var partStr = invalidCharsRegex.Replace(path, "_");
+        if (char.IsDigit(partStr[0]))
+            partStr = "_" + partStr;
+        return partStr;
+    }
+}

--- a/src/ThisAssembly.Resources/CSharp.sbntxt
+++ b/src/ThisAssembly.Resources/CSharp.sbntxt
@@ -16,7 +16,7 @@
 		/// => @"{{ $0.Path }}"
 		{{~ end ~}}
 		/// </summary>
-		public static partial class {{ $0.Name | string.replace "-" "_" | string.replace " " "_" }}
+		public static partial class {{ $0.Name }}
 		{
 			{{~ if $0.IsText ~}}
 			private static string text;

--- a/src/ThisAssembly.Resources/Model.cs
+++ b/src/ThisAssembly.Resources/Model.cs
@@ -27,14 +27,21 @@ record Area(string Name)
         var parts = basePath.Split(new[] { "\\", "/" }, StringSplitOptions.RemoveEmptyEntries);
         var end = resources.Count == 1 ? ^1 : ^0;
 
+        var parent = "Resources";
         foreach (var part in parts.AsSpan()[..end])
         {
-            var partStr = PathSanitizer.Sanitize(part);
+            var partStr = PathSanitizer.Sanitize(part, parent);
+            parent = partStr;
+
             area.NestedArea = new Area(partStr);
             area = area.NestedArea;
         }
 
-        area.Resources = resources;
+        area.Resources = resources
+            .Select(r => r with
+            {
+                Name = PathSanitizer.Sanitize(r.Name, parent),
+            });
         return root;
     }
 }

--- a/src/ThisAssembly.Resources/Model.cs
+++ b/src/ThisAssembly.Resources/Model.cs
@@ -40,7 +40,4 @@ record Area(string Name)
 }
 
 [DebuggerDisplay("{Name}")]
-record Resource(string Name, string? Comment, bool IsText)
-{
-    public string? Path { get; set; }
-};
+record Resource(string Name, string? Comment, bool IsText, string Path);

--- a/src/ThisAssembly.Resources/Model.cs
+++ b/src/ThisAssembly.Resources/Model.cs
@@ -29,22 +29,13 @@ record Area(string Name)
 
         foreach (var part in parts.AsSpan()[..end])
         {
-            var partStr = SanitizePart(part);
+            var partStr = PathSanitizer.Sanitize(part);
             area.NestedArea = new Area(partStr);
             area = area.NestedArea;
         }
 
         area.Resources = resources;
         return root;
-    }
-
-    static readonly Regex invalidCharsRegex = new(@"\W");
-    static string SanitizePart(string? part)
-    {
-        var partStr = invalidCharsRegex.Replace(part, "_");
-        if (char.IsDigit(partStr[0]))
-            partStr = "_" + partStr;
-        return partStr;
     }
 }
 

--- a/src/ThisAssembly.Resources/ResourcesGenerator.cs
+++ b/src/ThisAssembly.Resources/ResourcesGenerator.cs
@@ -76,10 +76,11 @@ namespace ThisAssembly
                         var name = group.Count() == 1
                             ? Path.GetFileNameWithoutExtension(f.resourceName)
                             : Path.GetExtension(f.resourceName)[1..];
-                        return new Resource(name, f.comment, isText)
-                        {
-                            Path = f.resourceName,
-                        };
+                        return new Resource(
+                            Name: PathSanitizer.Sanitize(name),
+                            Comment: f.comment,
+                            IsText: isText,
+                            Path: f.resourceName);
                     })
                     .ToList();
 

--- a/src/ThisAssembly.Resources/ResourcesGenerator.cs
+++ b/src/ThisAssembly.Resources/ResourcesGenerator.cs
@@ -77,7 +77,7 @@ namespace ThisAssembly
                             ? Path.GetFileNameWithoutExtension(f.resourceName)
                             : Path.GetExtension(f.resourceName)[1..];
                         return new Resource(
-                            Name: PathSanitizer.Sanitize(name),
+                            Name: name,
                             Comment: f.comment,
                             IsText: isText,
                             Path: f.resourceName);

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -56,5 +56,9 @@ namespace ThisAssemblyTests
         [Fact]
         public void CanUseSameNameDifferentExtensions()
             => Assert.NotNull(ThisAssembly.Resources.Content.Swagger.swagger_ui.css.GetBytes());
+
+        [Fact]
+        public void CanUseFileInvalidCharacters()
+            => Assert.NotNull(ThisAssembly.Resources.webhook_data.Text);
     }
 }

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -12,9 +12,7 @@
   <Import Project="..\*\*.props" />
 
   <ItemGroup>
-    <Compile Remove="..\EmbeddedResource.cs" />
-    <Compile Remove="..\GeneratorExtension.cs" />
-    <Compile Remove="..\IsExternalInit.cs" />
+    <Compile Remove="..\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates ThisAssembly.Resources to properly sanitize every path part. PathSanitizer is moved to common code to be used by ThisAssembly.Strings in the future; but ThisAssembly.Strings is not updated to use it in this PR.

Fixes #167 