### PR TITLE
Fix missing source link information in ThisAssembly.Git

### DIFF
--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -32,7 +32,10 @@
     <PackageReference Include="Devlooped.SponsorLink" Version="0.7.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.Common" Version="1.1.1" Pack="true" ExcludeAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageFile Include="Microsoft.SourceLink.Common" Version="1.1.1" PackFolder="Dependency" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Try switching to a package file for the common dependency. It seems to be interfering with properly collecting the sourcelink info otherwise.