### PR TITLE
Deduplicate project properties before generation

### DIFF
--- a/src/ThisAssembly.Project/ThisAssembly.Project.targets
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.targets
@@ -8,8 +8,11 @@
   
   <Target Name="InjectThisAssemblyProject" DependsOnTargets="$(InjectThisAssemblyProjectDependsOn)" 
           BeforeTargets="PrepareForBuild;CompileDesignTime;GenerateMSBuildEditorConfigFileShouldRun">
+    <ItemGroup>
+      <ProjectPropertyDistinct Include="@(ProjectProperty -> Distinct())" />
+    </ItemGroup>
     <PropertyGroup>
-      <ThisAssemblyProject>@(ProjectProperty, '|')</ThisAssemblyProject>
+      <ThisAssemblyProject>@(ProjectPropertyDistinct, '|')</ThisAssemblyProject>
     </PropertyGroup>
     <ItemGroup Condition="'$(ThisAssemblyProject)' != ''">
       <CompilerVisibleProperty Include="@(ProjectProperty)" />

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -50,6 +50,7 @@
 
   <ItemGroup>
     <ProjectProperty Include="Foo" />
+    <ProjectProperty Include="Foo" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />
     <Constant Include="Foo.Hello" Value="World" Comment="Comments make everything better 😍" />
     <FileConstant Include="@(None)" />


### PR DESCRIPTION
Avoids build failures due to misconfiguration.

Closes #172