### PR TITLE
Improve experience with empty values before first build

### DIFF
--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageFile Include="Microsoft.SourceLink.Common" Version="1.1.1" PackFolder="Dependency" />
+    <PackageFile Include="Microsoft.SourceLink.Common" Version="1.1.1" PackFolder="Dependency" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/src/ThisAssembly.Git/ThisAssembly.Git.targets
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.targets
@@ -67,7 +67,17 @@
   <Target Name="PrepareGitConstants"
           BeforeTargets="PrepareConstants"
           DependsOnTargets="InitializeGitInformation">
-    <ItemGroup>
+    <PropertyGroup>
+      <EmptySourceControlValue>[pending build]</EmptySourceControlValue>
+    </PropertyGroup>
+    <ItemGroup Condition="'$(EnableSourceControlManagerQueries)' != 'true'">
+      <Constant Include="Branch" Value="[pending build]" Root="Git" />
+      <Constant Include="Commit" Value="[pending build]" Root="Git" />
+      <Constant Include="Sha" Value="[pending build]" Root="Git" />
+      <Constant Include="Root" Value="[pending build]" Root="Git" />
+      <Constant Include="Url" Value="[pending build]" Root="Git" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(EnableSourceControlManagerQueries)' == 'true'">
       <Constant Include="Branch" Value="$(RepositoryBranch)" Root="Git" />
       <Constant Include="Commit" Value="$(RepositoryCommit)" Root="Git" />
       <Constant Include="Sha" Value="$(RepositorySha)" Root="Git" />


### PR DESCRIPTION
Make it less weird that all Git properties are empty before the first build, by setting a temporary "[pending build]" value that is gone after the first actual build.