### PR TITLE
Improve detection of supported SourceLink Git provider

### DIFF
--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -34,8 +34,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageFile Include="Microsoft.SourceLink.Common" Version="1.1.1" PackFolder="Dependency" Visible="false" />
-  </ItemGroup>
-
 </Project>

--- a/src/ThisAssembly.Git/ThisAssembly.Git.targets
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.targets
@@ -35,7 +35,7 @@
   <!-- Make sure git info is available before calling source generators -->
   <Target Name="InitializeGitInformation"
           BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
-          DependsOnTargets="InitializeSourceControlInformation">
+          DependsOnTargets="InitializeSourceControlInformation;$(SourceLinkUrlInitializerTargets)">
 
     <PropertyGroup Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">
       <!-- The project must specify PublishRepositoryUrl=true in order to publish the URL, in order to prevent inadvertent leak of internal URL. -->
@@ -54,8 +54,11 @@
 
     <PropertyGroup>
       <RepositoryRoot>@(_ThisAssemblyGitSourceRoot)</RepositoryRoot>
+      <SourceLinkUrl>@(_ThisAssemblyGitSourceRoot -> '%(SourceLinkUrl)')</SourceLinkUrl>
     </PropertyGroup>
 
+    <Warning Code="THIS002" Text="A valid SourceLink provider does not seem to be installed for the current repository/project. Values will be empty." Condition="'$(SourceLinkUrl)' == ''" />
+    
     <PropertyGroup Condition="'$(RepositoryBranch)' == '' and '$(RepositoryRoot)' != ''">
       <!-- We may not be in CI at all. If we got a git repo root, we can directly read HEAD -->
       <RepositoryHead>$(RepositoryRoot).git/HEAD</RepositoryHead>


### PR DESCRIPTION
Instead of declaring a dependency on Microsoft.SourceLink.Common, just detect a missing provider by the lack of a SourceLinkUrl on the source root (or an empty source root altogether).

Warn in that case, so it's clearer that the other package will be needed to populate the right values.