### PR TITLE
Downgrade CodeAnalysis dependency to allow running on older compilers

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
@@ -35,7 +35,7 @@ on the `ThisAssembly.Info` class.
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
@@ -55,7 +55,7 @@ C#:
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
+++ b/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
@@ -47,7 +47,7 @@ C#:
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Project/ThisAssembly.Project.csproj
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.csproj
@@ -46,7 +46,7 @@ C#:
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -32,7 +32,7 @@ such as "Hello {name}".
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />


### PR DESCRIPTION
Since we only need 4.0.1 to get incremental source generators, stick to that version. This allows VS2022 RTM and up (see https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022).