### PR TITLE
Bump to CDN-optimized SponsorLink

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
@@ -27,7 +27,7 @@ on the `ThisAssembly.Info` class.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
@@ -47,7 +47,7 @@ C#:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
+++ b/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
@@ -39,7 +39,7 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Project/ThisAssembly.Project.csproj
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.csproj
@@ -38,7 +38,7 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -24,7 +24,7 @@ such as "Hello {name}".
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
     <PackageReference Include="NuGetizer" Version="0.9.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.8.2" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This version is far more optimal since it leverages a 12hr CDN-caching for all checked artifacts.