### PR TITLE
Fix missing first character of local branch name

### DIFF
--- a/src/ThisAssembly.Git/ThisAssembly.Git.targets
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.targets
@@ -62,7 +62,8 @@
     <PropertyGroup Condition="'$(RepositoryBranch)' == '' and '$(RepositoryRoot)' != ''">
       <!-- We may not be in CI at all. If we got a git repo root, we can directly read HEAD -->
       <RepositoryHead>$(RepositoryRoot).git/HEAD</RepositoryHead>
-      <RepositoryBranch Condition="Exists($(RepositoryHead))">$([System.IO.File]::ReadAllText($(RepositoryHead)).TrimStart("ref: refs/heads/"))</RepositoryBranch>
+      <RepositoryBranch Condition="Exists($(RepositoryHead))">$([System.IO.File]::ReadAllText($(RepositoryHead)).Trim())</RepositoryBranch>
+      <RepositoryBranch Condition="$(RepositoryBranch) != ''">$(RepositoryBranch.TrimStart("ref:").Trim().TrimStart("refs").Trim("/").TrimStart("heads").Trim("/").Trim())</RepositoryBranch>
     </PropertyGroup>
 
   </Target>


### PR DESCRIPTION
The replacement string seems to be considered a regex because it's replacing more than it matches as a string only. So replace it with multiple replacements instead.