### PR TITLE
Only surface build and analyzer from SponsorLink

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
@@ -27,8 +27,8 @@ on the `ThisAssembly.Info` class.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.6.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
@@ -47,8 +47,8 @@ C#:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.6.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
+++ b/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
@@ -39,8 +39,8 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.6.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Prerequisites/ThisAssembly.Prerequisites.csproj
+++ b/src/ThisAssembly.Prerequisites/ThisAssembly.Prerequisites.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Project/SponsorLink.cs
+++ b/src/ThisAssembly.Project/SponsorLink.cs
@@ -11,6 +11,10 @@ class SponsorLinker : SponsorLink
     public SponsorLinker() : base(SponsorLinkSettings.Create(
         "devlooped", "ThisAssembly",
         packageId: "ThisAssembly.Project",
-        version: typeof(SponsorLinker).Assembly.GetName().Version.ToString(2)))
+        version: typeof(SponsorLinker).Assembly.GetName().Version.ToString(2)
+#if DEBUG
+        , quietDays: 0
+#endif
+        ))
     { }
 }

--- a/src/ThisAssembly.Project/ThisAssembly.Project.csproj
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.csproj
@@ -38,8 +38,8 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.6.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Resources/SponsorLink.cs
+++ b/src/ThisAssembly.Resources/SponsorLink.cs
@@ -11,6 +11,10 @@ class SponsorLinker : SponsorLink
     public SponsorLinker() : base(SponsorLinkSettings.Create(
         "devlooped", "ThisAssembly",
         packageId: "ThisAssembly.Resources",
-        version: typeof(SponsorLinker).Assembly.GetName().Version.ToString(2)))
+        version: typeof(SponsorLinker).Assembly.GetName().Version.ToString(2)
+#if DEBUG
+        , quietDays: 0
+#endif
+        ))
     { }
 }

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.6.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Strings/SponsorLink.cs
+++ b/src/ThisAssembly.Strings/SponsorLink.cs
@@ -11,6 +11,10 @@ class SponsorLinker : SponsorLink
     public SponsorLinker() : base(SponsorLinkSettings.Create(
         "devlooped", "ThisAssembly",
         packageId: "ThisAssembly.Strings",
-        version: typeof(SponsorLinker).Assembly.GetName().Version.ToString(2)))
+        version: typeof(SponsorLinker).Assembly.GetName().Version.ToString(2)
+#if DEBUG
+        , quietDays: 0
+#endif
+        ))
     { }
 }

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -24,8 +24,8 @@ such as "Hello {name}".
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" PackInclude="build,analyzers" PackExclude="compile,native,runtime" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.6.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.1" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ThisAssembly/ThisAssembly.csproj
+++ b/src/ThisAssembly/ThisAssembly.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="0.9.1" />
+    <PackageReference Include="NuGetizer" Version="0.9.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <Compile Remove="..\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
When referencing ThisAssembly, no SponsorLink APIs should be exposed to consumers.