### PR TITLE
Fix build issue when string resource has newlines

### DIFF
--- a/src/ThisAssembly.Strings/Model.cs
+++ b/src/ThisAssembly.Strings/Model.cs
@@ -51,7 +51,11 @@ static class ResourceFile
             if (valueElement == null)
                 continue;
 
-            var comment = element.Element("comment")?.Value?.Replace("<", "&lt;").Replace(">", "&gt;");
+            var comment = element.Element("comment")?.Value?
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\r\n", " ").Replace("\n", " ");
+
             var areaParts = id.Split(new[] { "_" }, StringSplitOptions.RemoveEmptyEntries);
             if (areaParts.Length <= 1)
             {


### PR DESCRIPTION
The value when no Comment is provided in teh resource file is used to make up the code comment for the generated property. This breaks if the value has newlines in it.

A workaround is for users to provide a shorter description in the resx, but we now also sanitize the value by replacing newlines with a whitespace.