### PR TITLE
ThisAssembly should not propagate transitively by default

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -9,6 +9,8 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <RestoreSources>https://api.nuget.org/v3/index.json;https://pkg.kzu.io/index.json;</RestoreSources>
 
+    <!-- ThisAssembly shouldn't propagate transitively by default -->
+    <DevelopmentDependency>true</DevelopmentDependency>
     <PackageProjectUrl>https://clarius.org/ThisAssembly</PackageProjectUrl>
 
     <!-- See https://github.com/scriban/scriban#source-embedding -->


### PR DESCRIPTION
Since we typically generate code that's intended for consumption within the project itself, we shouldn't cause other projects referencing the consuming project to also get ThisAssembly stuff.

Fixes #210