### PR TITLE
Bump to latest SponsorLink and ensure private assets always

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
@@ -27,8 +27,8 @@ on the `ThisAssembly.Info` class.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.7.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.targets
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.targets
@@ -1,0 +1,9 @@
+<Project>
+
+  <ItemGroup>
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.AssemblyInfo" PrivateAssets="all" PackTransitive="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
@@ -47,8 +47,8 @@ C#:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.7.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
@@ -5,6 +5,10 @@
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Comment" />
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Value" />
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Root" />
+
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.Constants" PrivateAssets="all" PackTransitive="false" />
   </ItemGroup>
 
   <ItemDefinitionGroup>

--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Git/ThisAssembly.Git.targets
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.targets
@@ -1,5 +1,11 @@
 <Project>
 
+  <ItemGroup>
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.Git" PrivateAssets="all" PackTransitive="false" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(RepositoryBranch)' == ''">
     <!-- GitHub Actions: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables -->
     <RepositoryBranch Condition="'$(RepositoryBranch)' == '' and '$(GITHUB_REF)' != '' and $(GITHUB_REF.Contains('refs/pull/'))">pr$(GITHUB_REF.Replace('refs/pull/', '').Replace('/merge', ''))</RepositoryBranch>

--- a/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
+++ b/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
@@ -39,8 +39,12 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <None Remove="ThisAssembly.Metadata.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.7.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Metadata/ThisAssembly.Metadata.targets
+++ b/src/ThisAssembly.Metadata/ThisAssembly.Metadata.targets
@@ -1,0 +1,9 @@
+<Project>
+
+  <ItemGroup>
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.Metadata" PrivateAssets="all" PackTransitive="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/ThisAssembly.Prerequisites/ThisAssembly.Prerequisites.csproj
+++ b/src/ThisAssembly.Prerequisites/ThisAssembly.Prerequisites.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/ThisAssembly.Project/ThisAssembly.Project.csproj
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.csproj
@@ -38,8 +38,8 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.7.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Project/ThisAssembly.Project.targets
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.targets
@@ -1,5 +1,11 @@
 <Project>
 
+  <ItemGroup>
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.Project" PrivateAssets="all" PackTransitive="false" />
+  </ItemGroup>
+
   <PropertyGroup>
     <InjectThisAssemblyProjectDependsOn Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">
       InitializeSourceControlInformation
@@ -15,7 +21,7 @@
       <ThisAssemblyProject>@(ProjectPropertyDistinct, '|')</ThisAssemblyProject>
     </PropertyGroup>
     <ItemGroup Condition="'$(ThisAssemblyProject)' != ''">
-      <CompilerVisibleProperty Include="@(ProjectProperty)" />
+      <CompilerVisibleProperty Include="@(ProjectPropertyDistinct)" />
       <CompilerVisibleProperty Include="ThisAssemblyProject" />
     </ItemGroup>
   </Target>

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -23,8 +23,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.7.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.targets
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.targets
@@ -1,6 +1,12 @@
 <Project>
 
   <ItemGroup>
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.Resources" PrivateAssets="all" PackTransitive="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <CompilerVisibleProperty Include="EmbeddedResourceStringExtensions" />
 
     <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemType" />

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -24,8 +24,8 @@ such as "Hello {name}".
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="42.42.213-main" />
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
     <PackageReference Include="Scriban" Version="5.7.0" Pack="false" IncludeAssets="build" />

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.targets
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.targets
@@ -1,5 +1,11 @@
 <Project>
 
+  <ItemGroup>
+    <!-- Make sure we're always private to the referencing project. 
+         Prevents analyzers from "flowing out" of the referencing project. -->
+    <PackageReference Update="ThisAssembly.Strings" PrivateAssets="all" PackTransitive="false" />
+  </ItemGroup>
+
   <Target Name="_InjectResxAdditionalFiles"
           BeforeTargets="PrepareForBuild;CompileDesignTime;GenerateMSBuildEditorConfigFileShouldRun"
           DependsOnTargets="PrepareResourceNames">

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -31,7 +31,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="Devlooped.SponsorLink.Build" Version="42.42.213-main" />
+    <!-- Only needed because we're referencing via P2P and not getting the dependency -->
+    <PackageReference Include="Devlooped.SponsorLink" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ThisAssembly/ThisAssembly.csproj
+++ b/src/ThisAssembly/ThisAssembly.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="42.42.957-main" />
+    <PackageReference Include="NuGetizer" Version="42.42.972-main" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <Compile Remove="..\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
Since analyzers are transitive by default (unless PrivateAssets=all in the PackageReference), we could have been inadvertently generating ThisAssembly classes via project-to-project (P2P) references and causing potential type name conflicts (if InternalsVisibleTo is also in use).

This can happen if you add a package reference manually and forget to set PrivateAssets=all. But ThisAssembly is *always* intended to be private assets.

After some testing, it turns out that even if we set the PrivateAssets=all via targets provided by the package itself, we can prevent this abnormal (but perhaps easy to encounter?) situation from happening at all.

This is particularly necessary with the introduction of the SponsorLink checks, since those are analyzers too, and require compiler-visible properties to be surfaced.

By forcing PrivateAssets, we make sure SponsorLink analyzer never runs on P2P projects and only on the directly referencing one.