### PR TITLE
Remove obsolete [Generator] attribute on SponsorLink

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/SponsorLink.cs
+++ b/src/ThisAssembly.AssemblyInfo/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(

--- a/src/ThisAssembly.Constants/SponsorLink.cs
+++ b/src/ThisAssembly.Constants/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(

--- a/src/ThisAssembly.Git/SponsorLink.cs
+++ b/src/ThisAssembly.Git/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(

--- a/src/ThisAssembly.Metadata/SponsorLink.cs
+++ b/src/ThisAssembly.Metadata/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(

--- a/src/ThisAssembly.Project/SponsorLink.cs
+++ b/src/ThisAssembly.Project/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(

--- a/src/ThisAssembly.Resources/SponsorLink.cs
+++ b/src/ThisAssembly.Resources/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(

--- a/src/ThisAssembly.Strings/SponsorLink.cs
+++ b/src/ThisAssembly.Strings/SponsorLink.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ThisAssembly;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-[Generator]
 class SponsorLinker : SponsorLink
 {
     public SponsorLinker() : base(SponsorLinkSettings.Create(


### PR DESCRIPTION
We no longer depend on a source generator.