### PR TITLE
Allow using ThisAssembly.Resources and ThisAssembly.Strings SxS

### DIFF
--- a/src/ThisAssembly.Resources/ResourcesGenerator.cs
+++ b/src/ThisAssembly.Resources/ResourcesGenerator.cs
@@ -22,8 +22,8 @@ namespace ThisAssembly
             var files = context.AdditionalTextsProvider
                 .Combine(context.AnalyzerConfigOptionsProvider)
                 .Where(x =>
-                    x.Right.GetOptions(x.Left).TryGetValue("build_metadata.AdditionalFiles.SourceItemType", out var itemType)
-                    && itemType == "EmbeddedResource")
+                    x.Right.GetOptions(x.Left).TryGetValue("build_metadata.EmbeddedResource.ThisAssemblyResource", out var assemblyResource)
+                    && bool.TryParse(assemblyResource, out var isAssemblyResource) && isAssemblyResource)
                 .Where(x => x.Right.GetOptions(x.Left).TryGetValue("build_metadata.EmbeddedResource.Value", out var value) && value != null)
                 .Select((x, ct) =>
                 {

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.targets
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.targets
@@ -9,7 +9,7 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="EmbeddedResourceStringExtensions" />
 
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemType" />
+    <CompilerVisibleItemMetadata Include="EmbeddedResource" MetadataName="ThisAssemblyResource" />
     <CompilerVisibleItemMetadata Include="EmbeddedResource" MetadataName="Kind" />
     <CompilerVisibleItemMetadata Include="EmbeddedResource" MetadataName="Comment" />
     <CompilerVisibleItemMetadata Include="EmbeddedResource" MetadataName="Value" />
@@ -38,7 +38,8 @@
         <Area>$([MSBuild]::ValueOrDefault('%(AreaPath)', '').Replace('\', '.').Replace('/', '.'))</Area>
         <Value>%(AreaPath)%(FileExtension)</Value>
       </EmbeddedResource>
-      <AdditionalFiles Include="@(EmbeddedResource)" SourceItemType="EmbeddedResource" />
+      <EmbeddedResource ThisAssemblyResource="true" />
+      <AdditionalFiles Include="@(EmbeddedResource)" />
     </ItemGroup>
   </Target>
 

--- a/src/ThisAssembly.Strings/StringsGenerator.cs
+++ b/src/ThisAssembly.Strings/StringsGenerator.cs
@@ -33,12 +33,12 @@ namespace ThisAssembly
             var files = context.AdditionalTextsProvider
                 .Combine(context.AnalyzerConfigOptionsProvider)
                 .Where(x =>
-                    x.Right.GetOptions(x.Left).TryGetValue("build_metadata.AdditionalFiles.SourceItemType", out var itemType)
-                    && itemType == "ResourceString")
-                .Where(x => x.Right.GetOptions(x.Left).TryGetValue("build_metadata.AdditionalFiles.ManifestResourceName", out var value) && value != null)
+                    x.Right.GetOptions(x.Left).TryGetValue("build_metadata.ResxCode.ThisAssemblyStrings", out var resourceString)
+                    && bool.TryParse(resourceString, out var isResourceString) && isResourceString)
+                .Where(x => x.Right.GetOptions(x.Left).TryGetValue("build_metadata.ResxCode.ManifestResourceName", out var value) && value != null)
                 .Select((x, ct) =>
                 {
-                    x.Right.GetOptions(x.Left).TryGetValue("build_metadata.AdditionalFiles.ManifestResourceName", out var resourceName);
+                    x.Right.GetOptions(x.Left).TryGetValue("build_metadata.ResxCode.ManifestResourceName", out var resourceName);
                     return (fileName: Path.GetFileName(x.Left.Path), text: x.Left.GetText(ct), resourceName!);
                 })
                 .Where(x => x.text != null);

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.targets
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.targets
@@ -11,14 +11,15 @@
           DependsOnTargets="PrepareResourceNames">
     <ItemGroup>
       <ResxCode Include="@(EmbeddedResource)" 
+                ThisAssemblyStrings="true" 
                 Condition="'%(EmbeddedResource.Type)' == 'Resx' And '%(EmbeddedResource.WithCulture)' != 'true' And '%(EmbeddedResource.GenerateResource)' != 'false' And '%(EmbeddedResource.ManifestResourceName)' != ''" />
-      <AdditionalFiles Include="@(ResxCode -> '%(FullPath)')" SourceItemType="ResourceString" />
+      <AdditionalFiles Include="@(ResxCode)" />
     </ItemGroup>
   </Target>
 
   <ItemGroup>
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="SourceItemType" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="ManifestResourceName" />
+    <CompilerVisibleItemMetadata Include="ResxCode" MetadataName="ThisAssemblyStrings" />
+    <CompilerVisibleItemMetadata Include="ResxCode" MetadataName="ManifestResourceName" />
   </ItemGroup>
 
   <Import Condition="'$(ThisAssemblyPrerequisitesImported)' != 'true'" Project="ThisAssembly.Prerequisites.targets" />


### PR DESCRIPTION
This fixes an issue where the additional file metadata (as persisted by the generated editorconfig for that) is duplicated and overriden between these two packages since both use EmbeddedResource item to drive the source generator.

Switch to per-generator item metadata and avoid using AdditionalFiles item metadata, which has this problem.