### PR TITLE
Add PrepareProjectProperties as a public hook

### DIFF
--- a/src/ThisAssembly.Project/ThisAssembly.Project.targets
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.targets
@@ -11,8 +11,10 @@
       InitializeSourceControlInformation
     </InjectThisAssemblyProjectDependsOn>
   </PropertyGroup>
+
+  <Target Name="PrepareProjectProperties" />
   
-  <Target Name="InjectThisAssemblyProject" DependsOnTargets="$(InjectThisAssemblyProjectDependsOn)" 
+  <Target Name="InjectThisAssemblyProject" DependsOnTargets="$(InjectThisAssemblyProjectDependsOn);PrepareProjectProperties" 
           BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun">
     <ItemGroup>
       <ProjectPropertyDistinct Include="@(ProjectProperty -> Distinct())" />


### PR DESCRIPTION
This allows consumers to run targets that add project properties dynamically before the actual generation runs.