### PR TITLE
Use raw string literals if supported by the target language

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -17,6 +17,7 @@
     <PackageScribanIncludeSource>true</PackageScribanIncludeSource>
 
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <NoWarn>MSB3277;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">

--- a/src/ThisAssembly.AssemblyInfo/AssemblyInfoGenerator.cs
+++ b/src/ThisAssembly.AssemblyInfo/AssemblyInfoGenerator.cs
@@ -39,7 +39,7 @@ namespace ThisAssembly
                 .Collect();
 
             context.RegisterSourceOutput(
-                metadata.Combine(context.CompilationProvider.Select((s, _) => s.Language)),
+                metadata.Combine(context.ParseOptionsProvider),
                 GenerateSource);
         }
 
@@ -66,12 +66,15 @@ namespace ThisAssembly
             return new KeyValuePair<string, string>(key, value);
         }
 
-        static void GenerateSource(SourceProductionContext spc, (ImmutableArray<KeyValuePair<string, string>> attributes, string language) arg2)
+        static void GenerateSource(SourceProductionContext spc, (ImmutableArray<KeyValuePair<string, string>> attributes, ParseOptions parse) arg)
         {
-            var (attributes, language) = arg2;
+            var (attributes, parse) = arg;
 
             var model = new Model(attributes.ToList());
-            var file = language.Replace("#", "Sharp") + ".sbntxt";
+            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 11)
+                model.RawStrings = true;
+
+            var file = parse.Language.Replace("#", "Sharp") + ".sbntxt";
             var template = Template.Parse(EmbeddedResource.GetContent(file), file);
             var output = template.Render(model, member => member.Name);
 

--- a/src/ThisAssembly.AssemblyInfo/CSharp.sbntxt
+++ b/src/ThisAssembly.AssemblyInfo/CSharp.sbntxt
@@ -24,8 +24,14 @@ partial class ThisAssembly
     public static partial class Info
     {
         {{~ for prop in Properties ~}}
+        {{~ if RawStrings ~}}
+        public const string {{ prop.Key }} = 
+"""
+{{ prop.Value }}
+""";
+        {{~ else ~}}
         public const string {{ prop.Key }} = @"{{ prop.Value }}";
-
+        {{~ end ~}}
         {{~ end ~}}
     }
 }

--- a/src/ThisAssembly.AssemblyInfo/Model.cs
+++ b/src/ThisAssembly.AssemblyInfo/Model.cs
@@ -8,6 +8,7 @@ namespace ThisAssembly
     {
         public Model(IEnumerable<KeyValuePair<string, string>> properties) => Properties = properties.ToList();
 
+        public bool RawStrings { get; set; } = false;
         public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 
         public List<KeyValuePair<string, string>> Properties { get; }

--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
@@ -39,4 +39,8 @@ on the `ThisAssembly.Info` class.
     <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ThisAssembly.Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -22,7 +22,14 @@
     {
         {{~ for value in $0.Values ~}}
         {{- summary value ~}}
-	    public const string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} =  @"{{ value.Value }}";
+        {{~ if RawStrings ~}}
+	    public const string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} = 
+"""
+{{ value.Value }}
+""";
+        {{~ else ~}}
+	    public const string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} = @"{{ value.Value }}";
+        {{~ end ~}}
         {{~ end ~}}
 
         {{ for area in $0.NestedAreas 

--- a/src/ThisAssembly.Constants/Model.cs
+++ b/src/ThisAssembly.Constants/Model.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 [DebuggerDisplay("Values = {RootArea.Values.Count}")]
 record Model(Area RootArea)
 {
+    public bool RawStrings { get; set; } = false;
     public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 }
 

--- a/src/ThisAssembly.Metadata/CSharp.sbntxt
+++ b/src/ThisAssembly.Metadata/CSharp.sbntxt
@@ -24,8 +24,16 @@ partial class ThisAssembly
     public static partial class Metadata
     {
         {{~ for md in Metadata ~}}
-        /// <summary>{{ md.Key }} = {{ md.Value }}</summary>
+        /// <summary>{{ md.Key }} = {{ md.Value | string.split "\n" | array.first | string.replace "\r" "" | string.lstrip | string.rstrip }}</summary>
+        {{~ if RawStrings ~}}
+        public const string {{ md.Key }} = 
+"""
+{{ md.Value }}
+""";
+        {{~ else ~}}
+        /// <summary>{{ prop.Key }} = {{ prop.Value }}</summary>
         public const string {{ md.Key }} = @"{{ md.Value }}";
+        {{~ end ~}}
 
         {{~ end ~}}
     }

--- a/src/ThisAssembly.Metadata/Model.cs
+++ b/src/ThisAssembly.Metadata/Model.cs
@@ -8,6 +8,7 @@ namespace ThisAssembly
     {
         public Model(IEnumerable<KeyValuePair<string, string>> metadata) => Metadata = metadata.ToList();
 
+        public bool RawStrings { get; set; } = false;
         public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 
         public List<KeyValuePair<string, string>> Metadata { get; }

--- a/src/ThisAssembly.Project/CSharp.sbntxt
+++ b/src/ThisAssembly.Project/CSharp.sbntxt
@@ -24,9 +24,15 @@ partial class ThisAssembly
     public static partial class Project
     {
         {{~ for prop in Properties ~}}
+        {{~ if RawStrings ~}}
+        public const string {{ prop.Key }} = 
+"""
+{{ prop.Value }}
+""";
+        {{~ else ~}}
         /// <summary>{{ prop.Key }} = {{ prop.Value }}</summary>
         public const string {{ prop.Key }} = @"{{ prop.Value }}";
-
+        {{~ end ~}}
         {{~ end ~}}
     }
 }

--- a/src/ThisAssembly.Project/Model.cs
+++ b/src/ThisAssembly.Project/Model.cs
@@ -8,6 +8,7 @@ namespace ThisAssembly
     {
         public Model(IEnumerable<KeyValuePair<string, string>> properties) => Properties = properties.ToList();
 
+        public bool RawStrings { get; set; } = false;
         public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 
         public List<KeyValuePair<string, string>> Properties { get; }

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -19,8 +19,13 @@ public record class Tests(ITestOutputHelper Output)
 
     [Fact]
     public void CanUseInfoDescription()
-        => Assert.Equal(@"A Description
-with a newline".ReplaceLineEndings(), ThisAssembly.Info.Description.ReplaceLineEndings());
+        => Assert.Equal(
+            """
+            A Description
+                  with a newline and
+                  * Some "things" with quotes
+                  // Some comments too.
+            """.ReplaceLineEndings(), ThisAssembly.Info.Description.ReplaceLineEndings());
 
     [Fact]
     public void CanUseConstants()

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -3,8 +3,16 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>net7.0</TargetFramework>
+    <Multiline>
+      A Description
+      with a newline and
+      * Some "things" with quotes
+      // Some comments too.
+    </Multiline>
     <Description>A Description
-with a newline</Description>
+      with a newline and
+      * Some "things" with quotes
+      // Some comments too.</Description>
     <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">net472</TargetFramework>
     <RootNamespace>ThisAssemblyTests</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -54,6 +62,10 @@ with a newline</Description>
   <ItemGroup>
     <ProjectProperty Include="Foo" />
     <ProjectProperty Include="Foo" />
+    <ProjectProperty Include="Description" />
+    <!-- Multiline values that go through .editorconfig will get truncated, unfortunately -->
+    <ProjectProperty Include="Multiline" />
+    <Constant Include="Foo.Raw" Value="$(Multiline)" Comment="$(Multiline)" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />
     <Constant Include="Foo.Hello" Value="World" Comment="Comments make everything better 😍" />
     <FileConstant Include="@(None)" />
@@ -61,13 +73,14 @@ with a newline</Description>
       <Link>Included/%(Filename)%(Extension)</Link>
     </FileConstant>
     <AssemblyMetadata Include="Foo" Value="Bar" />
+    <AssemblyMetadata Include="Raw" Value="$(Multiline)" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\ThisAssembly.Strings\Model.cs" Link="Model.cs" />
   </ItemGroup>
 
-  <Import Project="..\ThisAssembly.Prerequisites.targets"/>
+  <Import Project="..\ThisAssembly.Prerequisites.targets" />
   <Import Project="..\*\*.targets" />
 
 </Project>


### PR DESCRIPTION
In the cases where the values go through .editorconfig (such as constants and project properties), this isn't necessary (or supported) right now since .editorconfig will truncate multi-line values

Closes #243