### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.csproj
@@ -27,7 +27,11 @@ on the `ThisAssembly.Info` class.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <Compile Remove="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
@@ -41,6 +45,10 @@ on the `ThisAssembly.Info` class.
 
   <ItemGroup>
     <InternalsVisibleTo Include="ThisAssembly.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="SponsorLink.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
@@ -38,6 +38,10 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="CSharp.sbntxt" />
     <None Remove="ThisAssembly.Constants.targets" />
   </ItemGroup>
@@ -47,7 +51,11 @@ C#:
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <None Include="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Git/ThisAssembly.Git.csproj
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.csproj
@@ -25,11 +25,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ThisAssembly.Constants\ThisAssembly.Constants.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
+++ b/src/ThisAssembly.Metadata/ThisAssembly.Metadata.csproj
@@ -39,11 +39,19 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="ThisAssembly.Metadata.targets" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <None Include="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Project/ThisAssembly.Project.csproj
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.csproj
@@ -38,7 +38,15 @@ C#:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <Compile Remove="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -19,11 +19,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLink.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="ThisAssembly.Resources.targets" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
@@ -37,6 +41,10 @@
 
   <ItemGroup>
     <EmbeddedResource Include="..\EmbeddedResource.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="SponsorLink.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -24,7 +24,7 @@ such as "Hello {name}".
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />
+    <!--<PackageReference Include="Devlooped.SponsorLink" Version="1.0.0" />-->
     <PackageReference Include="NuGetizer" Version="1.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
 
@@ -37,11 +37,16 @@ such as "Hello {name}".
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="SponsorLink.cs" />
     <Compile Remove="ThisAssembly.Strings.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="ThisAssembly.Strings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="SponsorLink.cs" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink