### PR TITLE
Fix improper generation of C# 11 raw strings

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/AssemblyInfoGenerator.cs
+++ b/src/ThisAssembly.AssemblyInfo/AssemblyInfoGenerator.cs
@@ -71,7 +71,7 @@ namespace ThisAssembly
             var (attributes, parse) = arg;
 
             var model = new Model(attributes.ToList());
-            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 11)
+            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 1100)
                 model.RawStrings = true;
 
             var file = parse.Language.Replace("#", "Sharp") + ".sbntxt";

--- a/src/ThisAssembly.Constants/ConstantsGenerator.cs
+++ b/src/ThisAssembly.Constants/ConstantsGenerator.cs
@@ -47,7 +47,7 @@ namespace ThisAssembly
             var file = parse.Language.Replace("#", "Sharp") + ".sbntxt";
             var template = Template.Parse(EmbeddedResource.GetContent(file), file);
             var model = new Model(rootArea);
-            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 11)
+            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 1100)
                 model.RawStrings = true;
 
             var output = template.Render(model, member => member.Name);

--- a/src/ThisAssembly.Metadata/MetadataGenerator.cs
+++ b/src/ThisAssembly.Metadata/MetadataGenerator.cs
@@ -61,7 +61,7 @@ namespace ThisAssembly
             var (attributes, parse) = arg;
 
             var model = new Model(attributes.ToList());
-            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 11)
+            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 1100)
                 model.RawStrings = true;
 
             var file = parse.Language.Replace("#", "Sharp") + ".sbntxt";

--- a/src/ThisAssembly.Project/ProjectPropertyGenerator.cs
+++ b/src/ThisAssembly.Project/ProjectPropertyGenerator.cs
@@ -40,7 +40,7 @@ namespace ThisAssembly
             var (properties, parse) = arg;
 
             var model = new Model(properties);
-            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 11)
+            if (parse is CSharpParseOptions cs && (int)cs.LanguageVersion >= 1100)
                 model.RawStrings = true;
 
             var file = parse.Language.Replace("#", "Sharp") + ".sbntxt";


### PR DESCRIPTION
LanguageVersion for C# 11 is (int)1100

See https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/LanguageVersion.cs#L216

Fixes https://github.com/devlooped/GitInfo/issues/311