### PR TITLE
Specify comparer when search resource name

### DIFF
--- a/src/EmbeddedResource.cs
+++ b/src/EmbeddedResource.cs
@@ -44,7 +44,7 @@ static class EmbeddedResource
             .Replace('\\', '.');
 
         var manifestResourceName = Assembly.GetExecutingAssembly()
-            .GetManifestResourceNames().FirstOrDefault(x => x.EndsWith(resourceName));
+            .GetManifestResourceNames().FirstOrDefault(x => x.EndsWith(resourceName, StringComparison.Ordinal));
 
         if (string.IsNullOrEmpty(manifestResourceName))
             throw new InvalidOperationException($"Did not find required resource ending in '{resourceName}' in assembly '{baseName}'.");


### PR DESCRIPTION
The following line causes [CA1310](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1310) to be flagged in a user project with code analysis enabled:

https://github.com/devlooped/ThisAssembly/blob/65f0469d80fc8583d22c3abd195ed72d9d596884/src/EmbeddedResource.cs#L38

It can fail the compilation of the host project if warnings are being treated as errors.

This PR updates the call to specify a comparer explicitly. The choice of `StringComparison.Ordinal` should be in line with [`Assembly.GetManifestResourceStream`](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getmanifestresourcestream) whose documentation states that `name` is “The case-sensitive name of the manifest resource being requested.”
