### PR TITLE
Sanitize multi-line default comment

### DIFF
--- a/src/ThisAssembly.Strings/Model.cs
+++ b/src/ThisAssembly.Strings/Model.cs
@@ -51,7 +51,8 @@ static class ResourceFile
             if (valueElement == null)
                 continue;
 
-            var comment = element.Element("comment")?.Value?
+            // Make sure we trim newlines and replace them with spaces for comments.
+            var comment = (element.Element("comment")?.Value ?? valueElement)
                 .Replace("<", "&lt;")
                 .Replace(">", "&gt;")
                 .Replace("\r\n", " ").Replace("\n", " ");

--- a/src/ThisAssembly.Tests/Resources.resx
+++ b/src/ThisAssembly.Tests/Resources.resx
@@ -132,4 +132,8 @@
   <data name="Named" xml:space="preserve">
     <value>Hello {first}, {last}. Should we call you {first}?</value>
   </data>
+  <data name="WithNewLine" xml:space="preserve">
+    <value>Hello, 
+World!</value>
+    </data>
 </root>


### PR DESCRIPTION
Just as we do for explicit comment.

Fixes #308