### PR TITLE
Allow format strings in ThisAssembly.Strings

### DIFF
--- a/src/ThisAssembly.Strings/CSharp.sbntxt
+++ b/src/ThisAssembly.Strings/CSharp.sbntxt
@@ -28,18 +28,22 @@
         {{~ if value.IsIndexedFormat ~}}
         {{- summary value ~}}
 	    public static string {{ value.Id }}(
-            {{- for arg in value.Format -}}
+            {{- for arg in value.Args -}}
             object arg{{~ arg ~}}{{ if !for.last }}, {{ end }}
             {{- end -}}) 
             => string.Format(
                 CultureInfo.CurrentCulture,
-                Strings.GetResourceManager("{{ $1 }}").GetString("{{ value.Name }}"),
+                Strings.GetResourceManager("{{ $1 }}").GetString("{{ value.Name }}")
+                {{~ if value.HasArgFormat ~}}
+                {{- for arg in value.Format }}
+                .Replace("{{ arg.Value }}", "{%{{}%}{{ for.index }}{%{}}%}"){{- end -}}
+                {{~ end ~}},
                 {{ for arg in value.Format -}}
-                arg{{- arg -}}{{- if !for.last -}}, {{ end }}{{- end -}});
+                {{- if arg.Format -}}((IFormattable)arg{{- arg.Arg -}}).ToString("{{ arg.Format }}", CultureInfo.CurrentCulture){{- else -}}arg{{- arg.Arg -}}{{- end -}}{{- if !for.last -}}, {{ end }}{{- end -}});
         {{~ else if value.IsNamedFormat ~}}
         {{- summary value ~}}
 	    public static string {{ value.Id }}(
-            {{- for arg in value.Format -}}
+            {{- for arg in value.Args -}}
             object {{ arg ~}}{{ if !for.last }}, {{ end }}
             {{- end -}}) 
             => string.Format(
@@ -48,9 +52,9 @@
                     .GetResourceManager("{{ $1 }}")
                     .GetString("{{ value.Name }}")
                     {{- for arg in value.Format }}
-                    .Replace("{%{{}%}{{ arg }}{%{}}%}", "{%{{}%}{{ for.index }}{%{}}%}"){{- end -}},
+                    .Replace("{{ arg.Value }}", "{%{{}%}{{ for.index }}{%{}}%}"){{- end -}},
                 {{ for arg in value.Format -}}
-                {{- arg -}}{{- if !for.last -}}, {{ end }}{{- end -}});
+                {{- if arg.Format -}}((IFormattable){{- arg.Arg -}}).ToString("{{ arg.Format }}", CultureInfo.CurrentCulture){{- else -}}{{- arg.Arg -}}{{- end -}}{{- if !for.last -}}, {{ end }}{{- end -}});
 
         {{~ end ~}}
         {{~ end ~}}

--- a/src/ThisAssembly.Strings/readme.md
+++ b/src/ThisAssembly.Strings/readme.md
@@ -18,6 +18,7 @@ Given the following Resx file:
 | Infrastructure_MissingService | Service {0} is required.              | For logging only! |
 | Shopping_NoShipping           | We cannot ship {0} to {1}.            |                   |
 | Shopping_OutOfStock           | Product is out of stock at this time. |                   |
+| Shopping_AvailableOn          | Product available on {date:yyyy-MM}.  |                   |
 
 The following code would be generated:
 
@@ -53,6 +54,14 @@ partial class ThisAssembly
             /// </summary>
             public static string OutOfStock
                 => Strings.GetResourceManager("ThisStore.Properties.Resources").GetString("OutOfStock");
+
+            /// <summary>
+            /// Product available on {date:yyyy-MM}.
+            /// </summary>
+            public static string AvailableOn(object date) 
+                => string.Format(CultureInfo.CurrentCulture, 
+                    Strings.GetResourceManager("ThisAssemblyTests.Resources").GetString("WithNamedFormat").Replace("{date:yyyy-MM}", "{0}"), 
+                    ((IFormattable)date).ToString("yyyy-MM", CultureInfo.CurrentCulture));
         }
     }
 }

--- a/src/ThisAssembly.Tests/Resources.resx
+++ b/src/ThisAssembly.Tests/Resources.resx
@@ -132,8 +132,14 @@
   <data name="Named" xml:space="preserve">
     <value>Hello {first}, {last}. Should we call you {first}?</value>
   </data>
+  <data name="WithIndexedFormat" xml:space="preserve">
+    <value>Year {0:yyyy}, Month {0:MM}</value>
+  </data>
+  <data name="WithNamedFormat" xml:space="preserve">
+    <value>Year {date:yyyy}, Month {date:MM}</value>
+  </data>
   <data name="WithNewLine" xml:space="preserve">
     <value>Hello, 
 World!</value>
-    </data>
+  </data>
 </root>

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -9,6 +9,7 @@ namespace ThisAssemblyTests;
 
 public record class Tests(ITestOutputHelper Output)
 {
+    DateTime dxt = DateTime.Now;
     [Fact]
     public void CanReadResourceFile()
         => Assert.NotNull(ResourceFile.Load("Resources.resx", "Strings"));
@@ -62,6 +63,14 @@ public record class Tests(ITestOutputHelper Output)
     [Fact]
     public void CanUseStringsIndexedArguments()
         => Assert.NotNull(ThisAssembly.Strings.Indexed("hello", "world"));
+
+    [Fact]
+    public void CanUseStringsNamedFormattedArguments()
+        => Assert.Equal("Year 2020, Month 03", ThisAssembly.Strings.WithNamedFormat(new DateTime(2020, 3, 20)));
+
+    [Fact]
+    public void CanUseStringsIndexedFormattedArguments()
+        => Assert.Equal("Year 2020, Month 03", ThisAssembly.Strings.WithIndexedFormat(new DateTime(2020, 3, 20)));
 
     [Fact]
     public void CanUseStringResource()


### PR DESCRIPTION
The following are now valid and produce the expected results, just as an equivalent interpolated string would:

- `expires on {date:yyyy-MM-dd}`
- `expires on year {date:yyyy} (wait until {date:MM}`
- `expires on {0:yyyy-MM}`

Note how the same argument name can be used multiple times with different output formatting for increased flexibility and arg reuse.

Fixes #299