### PR TITLE
Automatically escape and unescape constants with semicolon

### DIFF
--- a/src/ThisAssembly.Constants/ConstantsGenerator.cs
+++ b/src/ThisAssembly.Constants/ConstantsGenerator.cs
@@ -25,6 +25,11 @@ namespace ThisAssembly
                     x.Right.GetOptions(x.Left).TryGetValue("build_metadata.Constant.Value", out var value);
                     x.Right.GetOptions(x.Left).TryGetValue("build_metadata.Constant.Comment", out var comment);
                     x.Right.GetOptions(x.Left).TryGetValue("build_metadata.Constant.Root", out var root);
+
+                    // Revert auto-escaping due to https://github.com/dotnet/roslyn/issues/51692
+                    if (value != null && value.StartsWith("|") && value.EndsWith("|"))
+                        value = value[1..^1].Replace('|', ';');
+
                     return (
                         name: Path.GetFileName(x.Left.Path),
                         value: value!,

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
@@ -44,7 +44,12 @@
           BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
           DependsOnTargets="PrepareResourceNames;PrepareConstants">
     <ItemGroup>
-      <AdditionalFiles Include="@(Constant)" SourceItemType="Constant" />
+      <!-- Automatically handle escaping of ; due to https://github.com/dotnet/roslyn/issues/51692 -->
+      <Constant Update="@(Constant)" Condition="$([MSBuild]::ValueOrdefault('%(Constant.Value)', '').Contains(';'))">
+        <Value>|$([MSBuild]::ValueOrdefault('%(Constant.Value)', '').Replace(';', '|'))|</Value>
+      </Constant>
+
+      <AdditionalFiles Include="@(Constant)" SourceItemType="Constant" />      
     </ItemGroup>
   </Target>
 

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -102,4 +102,8 @@ public record class Tests(ITestOutputHelper Output)
         Assert.NotEmpty(ThisAssembly.Git.Branch);
         Output.WriteLine(ThisAssembly.Git.Branch);
     }
+
+    [Fact]
+    public void CanUseSemicolonsInConstant()
+        => Assert.Equal("A;B;C", ThisAssembly.Constants.WithSemiColon);
 }

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -66,6 +66,7 @@
     <Constant Include="Foo.Raw" Value="$(Multiline)" Comment="$(Multiline)" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />
     <Constant Include="Foo.Hello" Value="World" Comment="Comments make everything better 😍" />
+    <Constant Include="WithSemiColon" Value="A;B;C" />
     <FileConstant Include="@(None)" />
     <FileConstant Update="@(FileConstant -&gt; WithMetadataValue('Filename', 'Readme'))">
       <Link>Included/%(Filename)%(Extension)</Link>


### PR DESCRIPTION
This is a workaround (fix?) for https://github.com/dotnet/roslyn/issues/51692, basically.

We lose all content after the first semicolon in constant and metadata values (presumably Git too).

Project properties also suffer from this, but merits unifying it with ThisAssembly.Constants to continue to streamline the implementation.