### PR TITLE
use inbox Powershell instead of pwsh

### DIFF
--- a/src/SponsorLink/SponsorLink.Analyzer.targets
+++ b/src/SponsorLink/SponsorLink.Analyzer.targets
@@ -187,7 +187,7 @@ partial class SponsorLink
   </Target>
 
   <Target Name="DownloadDevloopedJwk" BeforeTargets="GetAssemblyAttributes" Inputs="$(MSBuildProjectFullPath)" Outputs="$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)devlooped.jwk">
-    <Exec Command="pwsh -nop -f $(MSBuildThisFileDirectory)jwk.ps1" ConsoleToMSBuild="true" EchoOff="true">
+    <Exec Command="powershell -nop -f $(MSBuildThisFileDirectory)jwk.ps1" ConsoleToMSBuild="true" EchoOff="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="RawJwk"/>
       <Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
     </Exec>


### PR DESCRIPTION
Users who don't have the new Powershell installed get error because pwsh is not found so use normal Powershell.exe which is still part of Windows 10 and 11. 