### PR TITLE
After grace period, emit code with warnings

### DIFF
--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -5,6 +5,7 @@
     
 > This project uses SponsorLink and may issue IDE-only warnings if no active sponsorship is detected. Learn more at https://github.com/devlooped#sponsorlink.
 </Description>
+    <IsAnalyzer>$(PackFolder.StartsWith('analyzers/'))</IsAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,12 +13,14 @@
     <None Update="@(NoneWithoutCopyToOutputDirectory)" CopyToOutputDirectory="PreserveNewest" />
     <EmbeddedResource Include="@(None -> WithMetadataValue('Extension', '.sbntxt'))" />
     <None Update="@(None -> WithMetadataValue('Extension', '.sbntxt'))" Pack="true" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(IsAnalyzer)' == 'true'">
     <PackageFile Include="$(MSBuildThisFileDirectory)_._" PackagePath="lib/netstandard2.0/_._" />
     <PackageFile Include="*.props;*.targets" PackagePath="build\$(TargetFramework)\%(Filename)%(Extension)" Visible="true" />
   </ItemGroup>
 
-  <Target Name="PackCopyLocalLockFileAssemblies" Condition="'$(MergeAnalyzerAssemblies)' != 'true'" BeforeTargets="GetPackageContents" DependsOnTargets="ReferenceCopyLocalPathsOutputGroup">
+  <Target Name="PackCopyLocalLockFileAssemblies" Condition="'$(IsAnalyzer)' == 'true' and '$(MergeAnalyzerAssemblies)' != 'true'" BeforeTargets="GetPackageContents" DependsOnTargets="ReferenceCopyLocalPathsOutputGroup">
     <ItemGroup>
       <ReferenceCopyLocalAssemblies Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' 
         And !$([MSBuild]::ValueOrDefault('%(FileName)', '').EndsWith('.resources', StringComparison.OrdinalIgnoreCase))

--- a/src/Shared/EmbeddedResource.cs
+++ b/src/Shared/EmbeddedResource.cs
@@ -4,12 +4,18 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
-static class EmbeddedResource
+/// <summary>
+/// Allows easy access to embedded resources.
+/// </summary>
+public static class EmbeddedResource
 {
 #if DEBUG
     static readonly string baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? "";
 #endif
 
+    /// <summary>
+    /// Gets the content of the embedded resource at the specified relative path.
+    /// </summary>
     public static string GetContent(string relativePath)
     {
         using var stream = GetStream(relativePath);
@@ -17,6 +23,9 @@ static class EmbeddedResource
         return reader.ReadToEnd();
     }
 
+    /// <summary>
+    /// Gets the bytes of the embedded resource at the specified relative path.
+    /// </summary>
     public static byte[] GetBytes(string relativePath)
     {
         using var stream = GetStream(relativePath);
@@ -25,6 +34,10 @@ static class EmbeddedResource
         return bytes;
     }
 
+    /// <summary>
+    /// Gets the stream of the embedded resource at the specified relative path.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
     public static Stream GetStream(string relativePath)
     {
 #if DEBUG

--- a/src/Shared/PathSanitizer.cs
+++ b/src/Shared/PathSanitizer.cs
@@ -1,8 +1,15 @@
 ﻿using System.Text.RegularExpressions;
 
-static class PathSanitizer
+/// <summary>
+/// Sanitizes paths for use as identifiers.
+/// </summary>
+public static class PathSanitizer
 {
     static readonly Regex invalidCharsRegex = new(@"\W");
+
+    /// <summary>
+    /// Sanitizes the specified path for use as an identifier.
+    /// </summary>
     public static string Sanitize(string path, string parent)
     {
         var partStr = invalidCharsRegex.Replace(path, "_");

--- a/src/ThisAssembly.AssemblyInfo/CSharp.sbntxt
+++ b/src/ThisAssembly.AssemblyInfo/CSharp.sbntxt
@@ -7,6 +7,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System;
 using System.CodeDom.Compiler;
 using System.Runtime.CompilerServices;
 {{ if Namespace }}
@@ -21,16 +22,32 @@ partial class ThisAssembly
     /// <summary>
     /// Gets the AssemblyInfo attributes.
     /// </summary>
+    {{~ if Remarks ~}}
+    {{ Remarks }}
+    /// <see cref="{{ Url }}"/>
+    {{~ end ~}}
     [GeneratedCode("ThisAssembly.AssemblyInfo", "{{ Version }}")]
     [CompilerGenerated]
     public static partial class Info
     {
-        {{~ for prop in Properties ~}}
+        {{- for prop in Properties ~}}
+
+        {{~ if Remarks ~}}
+        {{ Remarks }}
+        /// <see cref="{{ Url }}"/>
+        {{~ end ~}}
+        {{~ if Warn ~}}
+        [Obsolete("{{ Warn }}", false
+        #if NET6_0_OR_GREATER
+            , UrlFormat = "{{ Url }}"
+        #endif
+        )]
+        {{~ end ~}}
         {{~ if RawStrings ~}}
         public const string {{ prop.Key }} = 
-"""
-{{ prop.Value }}
-""";
+            """
+            {{ prop.Value }}
+            """;
         {{~ else ~}}
         public const string {{ prop.Key }} = @"{{ prop.Value }}";
         {{~ end ~}}

--- a/src/ThisAssembly.AssemblyInfo/Model.cs
+++ b/src/ThisAssembly.AssemblyInfo/Model.cs
@@ -13,6 +13,9 @@ public class Model
     public string? Namespace { get; }
     public bool RawStrings { get; set; } = false;
     public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+    public string Url => Devlooped.Sponsors.SponsorLink.Funding.HelpUrl;
+    public string? Warn { get; set; }
+    public string? Remarks { get; set; }
 
     public List<KeyValuePair<string, string>> Properties { get; }
 }

--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -8,7 +8,7 @@
 //     the code is regenerated.
 // </auto-generated>
 //------------------------------------------------------------------------------
-{{ func summary }}
+{{- func summary -}}
 	    /// <summary>
         {{~ if $0.Comment ~}}
         /// {{ $0.Comment }}
@@ -16,12 +16,30 @@
 	    /// => @"{{ $0.Value }}"
         {{~ end ~}}
 	    /// </summary>
+{{- end -}}
+{{ func obsolete }}
+{{~ if Warn ~}}
+[Obsolete("{{ Warn }}", false
+#if NET6_0_OR_GREATER
+    , UrlFormat = "{{ Url }}"
+#endif
+)]
+
+{{~ end }}
+{{ end }}
+{{ func remarks }}
+{{~ if Remarks ~}}
+{{ Remarks }}
+/// <see cref="{{ Url }}"/>
+{{~ end ~}}
 {{ end }}
 {{ func render }}
     public static partial class {{ $0.Name | string.replace "-" "_" | string.replace " " "_" }}
     {
         {{~ for value in $0.Values ~}}
-        {{- summary value ~}}
+        {{- summary value -}}
+        {{- remarks -}}
+        {{ obsolete }}
         {{~ if RawStrings ~}}
 	    public const string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} = 
 """

--- a/src/ThisAssembly.Constants/ConstantsGenerator.cs
+++ b/src/ThisAssembly.Constants/ConstantsGenerator.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System.Diagnostics.Tracing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Devlooped.Sponsors;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -58,15 +60,26 @@ public class ConstantsGenerator : IIncrementalGenerator
             .Select((c, t) => c.GlobalOptions.TryGetValue("build_property.ThisAssemblyNamespace", out var ns) && !string.IsNullOrEmpty(ns) ? ns : null)
             .Combine(context.ParseOptionsProvider);
 
-        context.RegisterSourceOutput(
-            files.Combine(right),
-            GenerateConstant);
+        var inputs = files.Combine(right);
+        // this is required to ensure status is registered properly independently of analyzer runs. 
+        var options = context.GetStatusOptions();
 
+        context.RegisterSourceOutput(inputs.Combine(options), GenerateConstant);
+        //(spc, source) =>
+        //{
+        //    var status = Diagnostics.GetOrSetStatus(source.Right);
+        //    var warn = IsEditor &&
+        //        (status == Devlooped.Sponsors.SponsorStatus.Unknown || status == Devlooped.Sponsors.SponsorStatus.Expired);
+
+        //    GenerateConstant(spc, source.Left, warn ? string.Format(
+        //        CultureInfo.CurrentCulture, Resources.Editor_Disabled, Funding.Product, Funding.HelpUrl) : null);
+        //});
     }
 
-    void GenerateConstant(SourceProductionContext spc, ((string name, string value, string? comment, string root), (string? ns, ParseOptions parse)) args)
+    void GenerateConstant(SourceProductionContext spc,
+        (((string name, string value, string? comment, string root), (string? ns, ParseOptions parse)), StatusOptions options) args)
     {
-        var ((name, value, comment, root), (ns, parse)) = args;
+        var (((name, value, comment, root), (ns, parse)), options) = args;
         var cs = (CSharpParseOptions)parse;
 
         if (!string.IsNullOrWhiteSpace(ns) &&
@@ -87,24 +100,31 @@ public class ConstantsGenerator : IIncrementalGenerator
         if ((int)cs.LanguageVersion >= 1100)
             model.RawStrings = true;
 
+        if (IsEditor)
+        {
+            var status = Diagnostics.GetOrSetStatus(options);
+            if (status == SponsorStatus.Unknown || status == SponsorStatus.Expired)
+            {
+                model.Warn = string.Format(CultureInfo.CurrentCulture, Resources.Editor_Disabled, Funding.Product, Funding.HelpUrl);
+                model.Remarks = Resources.Editor_DisabledRemarks;
+            }
+            else if (status == SponsorStatus.Grace && Diagnostics.TryGet() is { } grace && grace.Properties.TryGetValue(nameof(SponsorStatus.Grace), out var days))
+            {
+                model.Remarks = string.Format(CultureInfo.CurrentCulture, Resources.Editor_GraceRemarks, days);
+            }
+        }
+
         var output = template.Render(model, member => member.Name);
 
         // Apply formatting since indenting isn't that nice in Scriban when rendering nested 
         // structures via functions.
         if (parse.Language == LanguageNames.CSharp)
         {
-            output = SyntaxFactory.ParseCompilationUnit(output)
+            output = SyntaxFactory.ParseCompilationUnit(output, options: cs)
                 .NormalizeWhitespace()
                 .GetText()
                 .ToString();
         }
-        //else if (language == LanguageNames.VisualBasic)
-        //{
-        //    output = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseCompilationUnit(output)
-        //        .NormalizeWhitespace()
-        //        .GetText()
-        //        .ToString();
-        //}
 
         spc.AddSource($"{root}.{name}.g.cs", SourceText.From(output, Encoding.UTF8));
     }

--- a/src/ThisAssembly.Constants/Model.cs
+++ b/src/ThisAssembly.Constants/Model.cs
@@ -13,6 +13,9 @@ record Model(Area RootArea, string? Namespace)
 {
     public bool RawStrings { get; set; } = false;
     public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+    public string Url => Devlooped.Sponsors.SponsorLink.Funding.HelpUrl;
+    public string? Warn { get; set; }
+    public string? Remarks { get; set; }
 }
 
 [DebuggerDisplay("Name = {Name}, NestedAreas = {NestedAreas.Count}, Values = {Values.Count}")]

--- a/src/ThisAssembly.Strings/CSharp.sbntxt
+++ b/src/ThisAssembly.Strings/CSharp.sbntxt
@@ -16,11 +16,22 @@
 	    /// = "{{ $0.Value }}"
         {{~ end ~}}
 	    /// </summary>
+        {{~ if Remarks ~}}
+        {{ Remarks }}
+        /// <see cref="{{ Url }}"/>
+        {{~ end ~}}
+        {{~ if Warn ~}}
+        [Obsolete("{{ Warn }}", false
+        #if NET6_0_OR_GREATER
+            , UrlFormat = "{{ Url }}"
+        #endif
+        )]
+        {{~ end ~}}
 {{ end }}
 {{ func render }}
     public static partial class {{ $0.Id }}
     {
-        {{~ for value in $0.Values ~}}
+        {{~ for value in $0.Values }}
 		{{~ if!(value.HasFormat) ~}}
         {{- summary value ~}}
 	    public static string {{ value.Id }} => Strings.GetResourceManager("{{ $1 }}").GetString("{{ value.Name }}");
@@ -70,7 +81,7 @@ using System;
 using System.Globalization;
 {{ if Namespace }}
 namespace {{ Namespace }};
-{{~ end ~}}
+{{ end }}
 
 /// <summary>
 /// Provides access to the current assembly information.
@@ -80,5 +91,6 @@ partial class ThisAssembly
     /// <summary>
     /// Provides access to the assembly strings.
     /// </summary>
+    {{- remarks -}}
     {{ render RootArea ResourceName }}
 }

--- a/src/ThisAssembly.Strings/Model.cs
+++ b/src/ThisAssembly.Strings/Model.cs
@@ -10,6 +10,9 @@ using System.Xml.Linq;
 record Model(ResourceArea RootArea, string ResourceName, string? Namespace)
 {
     public string? Version => Assembly.GetExecutingAssembly().GetName().Version?.ToString(3);
+    public string Url => Devlooped.Sponsors.SponsorLink.Funding.HelpUrl;
+    public string? Warn { get; set; }
+    public string? Remarks { get; set; }
 }
 
 static class ResourceFile
@@ -131,8 +134,8 @@ static class ResourceFile
 [DebuggerDisplay("Id = {Id}, NestedAreas = {NestedAreas.Count}, Values = {Values.Count}")]
 record ResourceArea(string Id, string Prefix)
 {
-    public List<ResourceArea> NestedAreas { get; init; } = new List<ResourceArea>();
-    public List<ResourceValue> Values { get; init; } = new List<ResourceValue>();
+    public List<ResourceArea> NestedAreas { get; init; } = [];
+    public List<ResourceValue> Values { get; init; } = [];
 }
 
 [DebuggerDisplay("{Id} = {Value}")]

--- a/src/ThisAssembly.Tests/Funding.cs
+++ b/src/ThisAssembly.Tests/Funding.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Devlooped.Sponsors;
+
+partial class SponsorLink
+{
+    public partial class Funding
+    {
+        public const string HelpUrl = "https://github.com/devlooped#sponsorlink";
+    }
+}

--- a/src/ThisAssembly.Tests/ScribanTests.cs
+++ b/src/ThisAssembly.Tests/ScribanTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Scriban;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ThisAssemblyTests;
+
+public class ScribanTests(ITestOutputHelper Console)
+{
+    [Fact]
+    public void CanRenderModel()
+    {
+        var source =
+            """
+            {{ func remarks }}
+            /// <see cref="{{ url }}"/>
+            {{ end }}
+            /// <summary>
+            /// {{ summary }}
+            /// </summary>
+            {{ remarks }}
+            """;
+
+        var template = Template.Parse(source);
+        var output = template.Render(new
+        {
+            summary = "This is a summary",
+            url = "https://github.com/devlooped#sponsorlink"
+        });
+
+        Assert.Contains("https://github.com/devlooped#sponsorlink", output);
+        Console.WriteLine(output);
+    }
+}

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -1,8 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using Devlooped;
 using Xunit;
 using Xunit.Abstractions;
+//using ThisAssembly = ThisAssemblyTests
 
 [assembly: SuppressMessage("SponsorLink", "SL04")]
 
@@ -10,7 +11,6 @@ namespace ThisAssemblyTests;
 
 public record class Tests(ITestOutputHelper Output)
 {
-    DateTime dxt = DateTime.Now;
     [Fact]
     public void CanReadResourceFile()
         => Assert.NotNull(ResourceFile.Load("Resources.resx", "Strings"));

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>net8.0</TargetFramework>
-    <ThisAssemblyNamespace>Devlooped</ThisAssemblyNamespace>
+    <ThisAssemblyNamespace>ThisAssemblyTests</ThisAssemblyNamespace>
     <Multiline>
       A Description
       with a newline and
@@ -17,10 +17,11 @@
     <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">net472</TargetFramework>
     <RootNamespace>ThisAssemblyTests</RootNamespace>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <NoWarn>CS8981;$(NoWarn)</NoWarn>
+    <NoWarn>CS0618;CS8981;TA100;$(NoWarn)</NoWarn>
+    <PackageScribanIncludeSource>false</PackageScribanIncludeSource>
   </PropertyGroup>
 
-  <Import Project="..\*\*.props" />
+  <Import Project="..\*\ThisAssembly*.props" />
 
   <ItemGroup>
     <Compile Remove="..\*.cs" />
@@ -40,6 +41,7 @@
     <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Scriban" Version="5.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
@@ -81,7 +83,7 @@
     <Compile Include="..\ThisAssembly.Strings\Model.cs" Link="Model.cs" />
   </ItemGroup>
 
-  <Import Project="..\SponsorLink\SponsorLink\buildTransitive\Devlooped.Sponsors.targets"/>
+  <Import Project="..\SponsorLink\SponsorLink\buildTransitive\Devlooped.Sponsors.targets" />
   <Import Project="..\*\ThisAssembly*.targets" />
   <Import Project="..\SponsorLink\SponsorLink.Analyzer.Tests.targets" />
 
@@ -91,6 +93,14 @@
   </PropertyGroup>
   <ItemGroup>
     <CompilerVisibleProperty Include="SponsorLinkNoInstallGrace" />
+  </ItemGroup>
+
+  <!-- Simulate SL_CollectDependencies -->
+  <PropertyGroup>
+    <ThisAssembly>$(Version)</ThisAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="ThisAssembly" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It was made quite clear that (some?) folks would rather just disable our friendly warning rather than sponsor. So we'll instead just make sponsorship mandatory.

See https://github.com/devlooped/ThisAssembly/issues/352#issuecomment-2325054917

I worked hard to accomodate very flexible options for sponsoring, and this project ain't maintaining itself. It's fine if folks use something else. I made this initially just for myself, and I'm glad it's been useful for others.

TODO: pending updating AssemblyInfo and Strings to use the same approach (those don't leverage Constants like the others).