### PR TITLE
Fix multiline values being truncated

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -11,7 +11,7 @@
 {{- func summary -}}
 	    /// <summary>
         {{~ if $0.Comment ~}}
-        /// {{ $0.Comment }}
+        {{ $0.Comment }}
         {{~ else ~}}
 	    /// => @"{{ $0.Value }}"
         {{~ end ~}}

--- a/src/ThisAssembly.Constants/ConstantsGenerator.cs
+++ b/src/ThisAssembly.Constants/ConstantsGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.Tracing;
+﻿using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -65,15 +65,6 @@ public class ConstantsGenerator : IIncrementalGenerator
         var options = context.GetStatusOptions();
 
         context.RegisterSourceOutput(inputs.Combine(options), GenerateConstant);
-        //(spc, source) =>
-        //{
-        //    var status = Diagnostics.GetOrSetStatus(source.Right);
-        //    var warn = IsEditor &&
-        //        (status == Devlooped.Sponsors.SponsorStatus.Unknown || status == Devlooped.Sponsors.SponsorStatus.Expired);
-
-        //    GenerateConstant(spc, source.Left, warn ? string.Format(
-        //        CultureInfo.CurrentCulture, Resources.Editor_Disabled, Funding.Product, Funding.HelpUrl) : null);
-        //});
     }
 
     void GenerateConstant(SourceProductionContext spc,
@@ -92,7 +83,13 @@ public class ConstantsGenerator : IIncrementalGenerator
             return;
         }
 
-        var rootArea = Area.Load([new(name, value, comment),], root);
+        if (comment != null)
+            comment = "/// " + string.Join(Environment.NewLine + "/// ", comment.Trim().Replace("\\n", Environment.NewLine).Trim(['\r', '\n']).Split([Environment.NewLine], StringSplitOptions.None));
+        else
+            comment = "/// " + string.Join(Environment.NewLine + "/// ", value.Replace("\\n", Environment.NewLine).Trim(['\r', '\n']).Split([Environment.NewLine], StringSplitOptions.None));
+
+        // Revert normalization of newlines performed in MSBuild to workaround the limitation in editorconfig.
+        var rootArea = Area.Load([new(name, value.Replace("\\n", Environment.NewLine).Trim(['\r', '\n']), comment),], root);
         // For now, we only support C# though
         var file = parse.Language.Replace("#", "Sharp") + ".sbntxt";
         var template = Template.Parse(EmbeddedResource.GetContent(file), file);

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
@@ -44,6 +44,13 @@
                 Value="%(FileConstant.Value)"
                 Comment="%(FileConstant.Comment)" />
     </ItemGroup>
+    <ItemGroup>
+      <!-- Normalize newlines to avoid losing content -->
+      <Constant Update="@(Constant)">
+        <Value>$([MSBuild]::ValueOrDefault('%(Constant.Value)', '').Replace($([System.Environment]::NewLine), '\n'))</Value>
+        <Comment>$([MSBuild]::ValueOrDefault('%(Constant.Comment)', '').Replace($([System.Environment]::NewLine), '\n'))</Comment>
+      </Constant>
+    </ItemGroup>
   </Target>
 
   <Target Name="_InjectConstantAdditionalFiles"

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -30,6 +30,16 @@ public record class Tests(ITestOutputHelper Output)
             """.ReplaceLineEndings(), ThisAssembly.Info.Description.ReplaceLineEndings());
 
     [Fact]
+    public void CanUseMultilineProjectProperty()
+        => Assert.Equal(
+            """
+                  A Description
+                  with a newline and
+                  * Some "things" with quotes
+                  // Some comments too.
+            """.ReplaceLineEndings(), ThisAssembly.Project.Multiline.ReplaceLineEndings());
+
+    [Fact]
     public void CanUseConstants()
         => Assert.Equal("Baz", ThisAssembly.Constants.Foo.Bar);
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -64,7 +64,6 @@
     <ProjectProperty Include="Foo" />
     <ProjectProperty Include="Foo" />
     <ProjectProperty Include="Description" />
-    <!-- Multiline values that go through .editorconfig will get truncated, unfortunately -->
     <ProjectProperty Include="Multiline" />
     <Constant Include="Foo.Raw" Value="$(Multiline)" Comment="$(Multiline)" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />


### PR DESCRIPTION
Just like we do for semicolon-separated values (encoding them prior to persistence to editorconfig/analyzer config), we now encode newlines as `\n` and decode them prior to emitting source code.

This makes previously failing scenarios work (i.e. project properties) as well as fixing previously working ones in AssemblyInfo generator (i.e. Description property).

Fixes #390