### PR TITLE
Reuse doc on root namespace and add visibility doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -388,6 +388,8 @@ generated `ThisAssembly` class. Otherwise, it will be generated in the global na
 <!-- #strings -->
 <!-- src/ThisAssembly.Strings/readme.md#strings -->
 
+<!-- include ../visibility.md -->
+
 # Dogfooding
 
 [![CI Version](https://img.shields.io/endpoint?url=https://shields.kzu.io/vpre/Stunts/main&label=nuget.ci&color=brightgreen)](https://pkg.kzu.io/index.json)

--- a/src/ThisAssembly.AssemblyInfo/readme.md
+++ b/src/ThisAssembly.AssemblyInfo/readme.md
@@ -19,9 +19,7 @@ on the `ThisAssembly.Info` class.
 
 ![](https://raw.githubusercontent.com/devlooped/ThisAssembly/main/img/ThisAssembly.AssemblyInfo.png)
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
 <!-- #assembly -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Constants/readme.md
+++ b/src/ThisAssembly.Constants/readme.md
@@ -30,7 +30,6 @@ via environment variables or command line arguments. For example:
 The C# code could consume this constant as follows:
 
 ```csharp
-
 public HttpClient CreateHttpClient(string name, int? timeout = default)
 {
     HttpClient client = httpClientFactory.CreateClient(name);
@@ -65,9 +64,7 @@ Which results in:
 
 ![](https://raw.githubusercontent.com/devlooped/ThisAssembly/main/img/ThisAssembly.Constants2.png)
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
 <!-- #constants -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Git/readme.md
+++ b/src/ThisAssembly.Git/readme.md
@@ -70,10 +70,7 @@ packaging experience possible:
 </Project>
 ```
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
-
 <!-- #git -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Metadata/readme.md
+++ b/src/ThisAssembly.Metadata/readme.md
@@ -22,9 +22,7 @@ The metadata attribute can alternatively be declared using MSBuild syntax in the
   </ItemGroup>
 ```
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
 <!-- #metadata -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Project/readme.md
+++ b/src/ThisAssembly.Project/readme.md
@@ -17,9 +17,7 @@ them as `ProjectProperty` MSBuild items in the project file, such as:
 
 ![](https://raw.githubusercontent.com/devlooped/ThisAssembly/main/img/ThisAssembly.Project.png)
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
 <!-- #project -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Resources/readme.md
+++ b/src/ThisAssembly.Resources/readme.md
@@ -43,9 +43,7 @@ treated as a text file:
 You can also add a `Comment` item metadata attribute, which will be used as the `<summary>` XML 
 doc for the generated member.
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
 <!-- #resources -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Strings/readme.md
+++ b/src/ThisAssembly.Strings/readme.md
@@ -68,9 +68,7 @@ partial class ThisAssembly
 }
 ```
 
-Set the `$(ThisAssemblyNamespace)` MSBuild property to set the root namespace of the 
-generated `ThisAssembly` class. Otherwise, it will be generated in the global namespace.
-
 <!-- #strings -->
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly/readme.md
+++ b/src/ThisAssembly/readme.md
@@ -22,5 +22,6 @@
 ## ThisAssembly.Strings
 <!-- include ../ThisAssembly.Strings/readme.md#strings -->
 
+<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/visibility.md
+++ b/src/visibility.md
@@ -1,0 +1,16 @@
+## Customizing the generated class
+
+Set the `$(ThisAssemblyNamespace)` MSBuild property to set the namespace of the 
+generated `ThisAssembly` root class. Otherwise, it will be generated in the global namespace.
+
+All generated classes are partial and have no visibility modifier, so they can be extended 
+manually with another partial that can add members or modify their visibility to make them 
+public, if needed. The C# default for this case is for all classes to be internal.
+
+```csharp
+// makes the generated classes public
+public partial ThisAssembly 
+{
+    public partial class Constants { }
+}
+```


### PR DESCRIPTION
Document more consistently the two ways users can customize generated code.