### PR TITLE
Allow setting visibility and switching to static readonly props

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -41,13 +41,13 @@
         {{- remarks -}}
         {{ obsolete }}
         {{~ if RawStrings && value.IsText ~}}
-	    public const string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} = 
+	    public {{ Modifier }} string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} ={{ Lambda }} 
 
 """
 {{ value.Value }}
 """;
         {{~ else ~}}
-	    public const {{ value.Type }} {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} = 
+	    public {{ Modifier }} {{ value.Type }} {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} ={{ Lambda }} 
             {{~ if value.IsText ~}}
             @"{{ value.Value }}";
             {{~ else ~}}
@@ -71,7 +71,7 @@ namespace {{ Namespace }};
 /// <summary>
 /// Provides access to the current assembly information.
 /// </summary>
-partial class ThisAssembly
+{{ Visibility }}partial class ThisAssembly
 {
     /// <summary>
     /// Provides access project-defined constants.

--- a/src/ThisAssembly.Constants/Model.cs
+++ b/src/ThisAssembly.Constants/Model.cs
@@ -9,13 +9,16 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace ThisAssembly;
 
 [DebuggerDisplay("Values = {RootArea.Values.Count}")]
-record Model(Area RootArea, string? Namespace)
+record Model(Area RootArea, string? Namespace, bool IsPublic)
 {
     public bool RawStrings { get; set; } = false;
     public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
     public string Url => Devlooped.Sponsors.SponsorLink.Funding.HelpUrl;
     public string? Warn { get; set; }
     public string? Remarks { get; set; }
+    public string Visibility => IsPublic ? "public " : "";
+    public string Modifier => IsPublic ? "static" : "const";
+    public string Lambda => IsPublic ? ">" : "";
 }
 
 [DebuggerDisplay("Name = {Name}, NestedAreas = {NestedAreas.Count}, Values = {Values.Count}")]

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
@@ -3,6 +3,7 @@
 
   <ItemGroup>
     <CompilerVisibleProperty Include="ThisAssemblyNamespace" />
+    <CompilerVisibleProperty Include="ThisAssemblyVisibility" />
 
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="ItemType" />
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Comment" />

--- a/src/ThisAssembly.Resources/CSharp.sbntxt
+++ b/src/ThisAssembly.Resources/CSharp.sbntxt
@@ -52,7 +52,7 @@ namespace {{ Namespace }};
 /// <summary>
 /// Provides access to the current assembly information.
 /// </summary>
-partial class ThisAssembly
+{{ Visibility }}partial class ThisAssembly
 {
     /// <summary>
     /// Provides access to assembly resources.

--- a/src/ThisAssembly.Resources/Model.cs
+++ b/src/ThisAssembly.Resources/Model.cs
@@ -7,9 +7,10 @@ using System.Reflection;
 namespace ThisAssembly;
 
 [DebuggerDisplay("Values = {RootArea.Values.Count}")]
-record Model(Area RootArea, string? Namespace)
+record Model(Area RootArea, string? Namespace, bool IsPublic)
 {
     public string Version => Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+    public string Visibility => IsPublic ? "public " : "";
 }
 
 [DebuggerDisplay("Name = {Name}")]

--- a/src/ThisAssembly.Resources/readme.md
+++ b/src/ThisAssembly.Resources/readme.md
@@ -43,7 +43,15 @@ treated as a text file:
 You can also add a `Comment` item metadata attribute, which will be used as the `<summary>` XML 
 doc for the generated member.
 
+## Customizing the generated code
+
+The following MSBuild properties can be used to customize the generated code:
+
+| Property                | Description                                                                                          |
+|-------------------------|------------------------------------------------------------------------------------------------------|
+| ThisAssemblyNamespace   | Sets the namespace of the generated `ThisAssembly` root class. If not set, it will be in the global namespace. |
+| ThisAssemblyVisibility  | Sets the visibility modifier of the generated `ThisAssembly` root class. If not set, it will be internal. |
+
 <!-- #resources -->
-<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Strings/CSharp.sbntxt
+++ b/src/ThisAssembly.Strings/CSharp.sbntxt
@@ -86,7 +86,7 @@ namespace {{ Namespace }};
 /// <summary>
 /// Provides access to the current assembly information.
 /// </summary>
-partial class ThisAssembly
+{{ Visibility }}partial class ThisAssembly
 {
     /// <summary>
     /// Provides access to the assembly strings.

--- a/src/ThisAssembly.Strings/Model.cs
+++ b/src/ThisAssembly.Strings/Model.cs
@@ -7,12 +7,13 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 [DebuggerDisplay("ResourceName = {ResourceName}, Values = {RootArea.Values.Count}")]
-record Model(ResourceArea RootArea, string ResourceName, string? Namespace)
+record Model(ResourceArea RootArea, string ResourceName, string? Namespace, bool IsPublic)
 {
     public string? Version => Assembly.GetExecutingAssembly().GetName().Version?.ToString(3);
     public string Url => Devlooped.Sponsors.SponsorLink.Funding.HelpUrl;
     public string? Warn { get; set; }
     public string? Remarks { get; set; }
+    public string Visibility => IsPublic ? "public " : "";
 }
 
 static class ResourceFile

--- a/src/ThisAssembly.Strings/readme.md
+++ b/src/ThisAssembly.Strings/readme.md
@@ -68,7 +68,15 @@ partial class ThisAssembly
 }
 ```
 
+## Customizing the generated code
+
+The following MSBuild properties can be used to customize the generated code:
+
+| Property                | Description                                                                                          |
+|-------------------------|------------------------------------------------------------------------------------------------------|
+| ThisAssemblyNamespace   | Sets the namespace of the generated `ThisAssembly` root class. If not set, it will be in the global namespace. |
+| ThisAssemblyVisibility  | Sets the visibility modifier of the generated `ThisAssembly` root class. If not set, it will be internal. |
+
 <!-- #strings -->
-<!-- include ../visibility.md -->
 <!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
 <!-- exclude -->

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <TargetFramework>net8.0</TargetFramework>
     <ThisAssemblyNamespace>ThisAssemblyTests</ThisAssemblyNamespace>
+    <ThisAssemblyVisibility>public</ThisAssemblyVisibility>
     <Multiline>
       A Description
       with a newline and

--- a/src/visibility.md
+++ b/src/visibility.md
@@ -3,14 +3,56 @@
 Set the `$(ThisAssemblyNamespace)` MSBuild property to set the namespace of the 
 generated `ThisAssembly` root class. Otherwise, it will be generated in the global namespace.
 
-All generated classes are partial and have no visibility modifier, so they can be extended 
-manually with another partial that can add members or modify their visibility to make them 
-public, if needed. The C# default for this case is for all classes to be internal.
+The generated root `ThisAssembly` class is partial and has no visibility modifier by default, 
+making it internal by default in C#.
+
+You can set the `$(ThisAssemblyVisibility)` MSBuild property to `public` to make it public. 
+This will also change all constants to be static readonly properties instead. 
+
+Default:
+```csharp
+partial class ThisAssembly
+{
+    public partial class Constants
+    {
+        public const string Hello = "World";
+    }
+}
+```
+
+In this case, the compiler will inline the constants directly into the consuming code at 
+the call site, which is optimal for performance for the common usage of constants.
+
+Public:
+```csharp
+public partial class ThisAssembly
+{
+    public partial class Constants
+    {
+        public static string Hello => "World";
+    }
+}
+```
+
+This makes it possible for consuming code to remain unchanged and not require 
+a recompile when the the values of `ThisAssembly` are changed in a referenced assembly.
+
+If you want to keep the properties as constants, you can instead extend the generated 
+code by defining a another partial that can modify its visibility as needed (or add 
+new members). 
 
 ```csharp
-// makes the generated classes public
+// makes the generated class public
 public partial ThisAssembly 
 {
-    public partial class Constants { }
+    // Nested classes are always public since the outer class 
+    // already limits their visibility
+    partial class Constants 
+    {
+        // add some custom constants
+        public const string MyConstant = "This isn't configurable via MSBuild";
+
+        // generated code will remain as constants
+    }
 }
 ```


### PR DESCRIPTION
Setting the `ThisAssembly` class to public should be somewhat rare, but might be desirable in some cases. When the class is made public, there's a surprising "bug" in that updating the assembly providing the `ThisAssembly` class will *not* cause another assembly consuming its values to reflect the changes. This is because the compiler will efectively inline the constants, so effectively every call site has a copy of the value.

This is somewhat unintuitive, but it's perfectly sensible when the use is for internal purposes.

The new ThisAssemblyVisibility=public property allows both setting the generated class visibility to and switching (for constants) to static properties.

For ThisAssembly.Strings and ThisAssembly.Resources, only the class visibility is changed.

Fixes #64