### PR TITLE
Remove doc on DateTime being invalid

### DIFF
--- a/src/ThisAssembly.Constants/readme.md
+++ b/src/ThisAssembly.Constants/readme.md
@@ -41,8 +41,7 @@ public HttpClient CreateHttpClient(string name, int? timeout = default)
 Note how the constant is typed to `int` as specified in the `Type` attribute in MSBuild. 
 The generated code uses the specified `Type` as-is, as well as the `Value` attribute in that 
 case, so it's up to the user to ensure they match and result in valid C# code. For example, 
-you can emit a boolean, long, double, etc., but a `DateTime` wouldn't be a valid constant even 
-if you set the `Value` to `DateTime.Now`. If no type is provided, `string` is assumed. Values 
+you can emit a boolean, long, double, etc.. If no type is provided, `string` is assumed. Values 
 can also be multi-line and will use [C# raw string literals](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/raw-string) 
 if supported by the target language version (11+).
 

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -64,6 +64,10 @@ public record class Tests(ITestOutputHelper Output)
         => Assert.Equal(1.23, ThisAssembly.Constants.TypedDouble);
 
     [Fact]
+    public void CanUseTypedTimeSpanStaticProp()
+        => Assert.Equal(TimeSpan.FromSeconds(5), ThisAssembly.Constants.TypedTimeSpan);
+
+    [Fact]
     public void CanUseFileConstants()
         => Assert.Equal(ThisAssembly.Constants.Content.Docs.License, Path.Combine("Content", "Docs", "License.md"));
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -17,7 +17,7 @@
       // Some comments too.</Description>
     <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">net472</TargetFramework>
     <RootNamespace>ThisAssemblyTests</RootNamespace>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
     <NoWarn>CS0618;CS8981;TA100;$(NoWarn)</NoWarn>
     <PackageScribanIncludeSource>false</PackageScribanIncludeSource>
   </PropertyGroup>
@@ -82,6 +82,8 @@
     <Constant Include="TypedLong" Value="123" Type="long" />
     <Constant Include="TypedDouble" Value="1.23" Type="double" />
     <Constant Include="TypedBoolean" Value="true" Type="bool" />
+    <!-- Since use use ThisAssemblyVisibility=public, this will turn into a static readonly prop with a lambda, so it works -->
+    <Constant Include="TypedTimeSpan" Value="TimeSpan.FromSeconds(5)" Type="TimeSpan" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since when using public visibility, it can be valid since they would be static readonly props with a lambda now.

For example, the following now works just fine:

```xml
<Constant Include="TypedTimeSpan" Value="TimeSpan.FromSeconds(5)" Type="TimeSpan" />
```

And generates:

```csharp
public static TimeSpan TypedTimeSpan => TimeSpan.FromSeconds(5);
```