### PR TITLE
Properly fix formatting error by switching to href

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -30,7 +30,7 @@
 {{ func remarks }}
 {{~ if Remarks ~}}
 {{ Remarks }}
-/// <see cref="{{ Url }}"/>
+/// <see href="{{ Url }}"/>
 {{~ end ~}}
 {{ end }}
 {{ func render }}

--- a/src/ThisAssembly.Constants/ConstantsGenerator.cs
+++ b/src/ThisAssembly.Constants/ConstantsGenerator.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Devlooped.Sponsors;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -17,8 +16,6 @@ namespace ThisAssembly;
 [Generator(LanguageNames.CSharp)]
 public class ConstantsGenerator : IIncrementalGenerator
 {
-    static readonly Regex SeeExpr = new("<see.+sponsorlink\"/>", RegexOptions.Compiled);
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var files = context.AdditionalTextsProvider
@@ -124,16 +121,13 @@ public class ConstantsGenerator : IIncrementalGenerator
         // structures via functions.
         if (parse.Language == LanguageNames.CSharp)
         {
-            output = SeeExpr.Replace(SyntaxFactory
+            output = SyntaxFactory
                 .ParseCompilationUnit(output, options: cs)
                 .NormalizeWhitespace()
                 .GetText()
-                .ToString(),
-                $"<see cref=\"{Funding.HelpUrl}\"/>");
+                .ToString();
         }
 
         spc.AddSource($"{root}.{name}.g.cs", SourceText.From(output, Encoding.UTF8));
     }
-
-
 }

--- a/src/ThisAssembly.Resources/CSharp.sbntxt
+++ b/src/ThisAssembly.Resources/CSharp.sbntxt
@@ -18,7 +18,7 @@
 		/// </summary>
         {{~ if Remarks ~}}
         {{ Remarks }}
-        /// <see cref="{{ Url }}"/>
+        /// <see href="{{ Url }}"/>
         {{~ end ~}}
         {{~ if Warn ~}}
         [Obsolete("{{ Warn }}", false

--- a/src/ThisAssembly.Resources/ResourcesGenerator.cs
+++ b/src/ThisAssembly.Resources/ResourcesGenerator.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Devlooped.Sponsors;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -17,8 +16,6 @@ namespace ThisAssembly;
 [Generator(LanguageNames.CSharp)]
 public class ResourcesGenerator : IIncrementalGenerator
 {
-    static readonly Regex SeeExpr = new("<see.+sponsorlink\"/>", RegexOptions.Compiled);
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(
@@ -124,12 +121,11 @@ public class ResourcesGenerator : IIncrementalGenerator
             };
             var output = template.Render(model, member => member.Name);
 
-            output = SeeExpr.Replace(SyntaxFactory
+            output = SyntaxFactory
                 .ParseCompilationUnit(output, options: parse as CSharpParseOptions)
                 .NormalizeWhitespace()
                 .GetText()
-                .ToString(),
-                $"<see cref=\"{Funding.HelpUrl}\"/>");
+                .ToString();
 
             spc.AddSource(
                 $"{basePath.Replace('\\', '.').Replace('/', '.')}.g.cs",

--- a/src/ThisAssembly.Strings/CSharp.sbntxt
+++ b/src/ThisAssembly.Strings/CSharp.sbntxt
@@ -18,7 +18,7 @@
 	    /// </summary>
         {{~ if Remarks ~}}
         {{ Remarks }}
-        /// <see cref="{{ Url }}"/>
+        /// <see href="{{ Url }}"/>
         {{~ end ~}}
         {{~ if Warn ~}}
         [Obsolete("{{ Warn }}", false

--- a/src/ThisAssembly.Strings/StringsGenerator.cs
+++ b/src/ThisAssembly.Strings/StringsGenerator.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using Devlooped.Sponsors;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -16,8 +15,6 @@ namespace ThisAssembly;
 [Generator(LanguageNames.CSharp)]
 public class StringsGenerator : IIncrementalGenerator
 {
-    static readonly Regex SeeExpr = new("<see.+sponsorlink\"/>", RegexOptions.Compiled);
-
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Read the ThisAssemblyNamespace property or default to null
@@ -85,12 +82,11 @@ public class StringsGenerator : IIncrementalGenerator
 
         var output = template.Render(model, member => member.Name);
 
-        output = SeeExpr.Replace(SyntaxFactory
+        output = SyntaxFactory
             .ParseCompilationUnit(output, options: parse as CSharpParseOptions)
             .NormalizeWhitespace()
             .GetText()
-            .ToString(),
-            $"<see cref=\"{Funding.HelpUrl}\"/>");
+            .ToString();
 
         spc.AddSource(resourceName, SourceText.From(output, Encoding.UTF8));
     }


### PR DESCRIPTION
We were using cref, which is for API members, which is what was causing the formatting error in the first place.

Fixes #408