### PR TITLE
Allow constants to define custom root comment summary

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -74,7 +74,7 @@ namespace {{ Namespace }};
 {{ Visibility }}partial class ThisAssembly
 {
     /// <summary>
-    /// Provides access project-defined constants.
+    /// {{ RootArea.Comment }}
     /// </summary>
     {{ render RootArea }}
 }

--- a/src/ThisAssembly.Constants/Model.cs
+++ b/src/ThisAssembly.Constants/Model.cs
@@ -22,7 +22,7 @@ record Model(Area RootArea, string? Namespace, bool IsPublic)
 }
 
 [DebuggerDisplay("Name = {Name}, NestedAreas = {NestedAreas.Count}, Values = {Values.Count}")]
-record Area(string Name, string Prefix)
+record Area(string Name, string Prefix, string Comment)
 {
     public List<Area> NestedAreas { get; init; } = new();
     public List<Constant> Values { get; init; } = new();
@@ -48,9 +48,9 @@ record Area(string Name, string Prefix)
         return result;
     }
 
-    public static Area Load(List<Constant> constants, string rootArea = "Constants")
+    public static Area Load(List<Constant> constants, string rootArea = "Constants", string comment = "Provides access project-defined constants.")
     {
-        var root = new Area(rootArea, "");
+        var root = new Area(rootArea, "", comment);
 
         foreach (var constant in constants)
         {
@@ -96,7 +96,7 @@ record Area(string Name, string Prefix)
                         "Area name '{0}' is already in use as a value name under area '{1}'.",
                         areaName, currentArea.Name));
 
-                existing = new Area(areaName, currentArea.Prefix + areaName + ".");
+                existing = new Area(areaName, currentArea.Prefix + areaName + ".", "");
                 currentArea.NestedAreas.Add(existing);
             }
 

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
@@ -10,6 +10,7 @@
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Value" />
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Type" />
     <CompilerVisibleItemMetadata Include="Constant" MetadataName="Root" />
+    <CompilerVisibleItemMetadata Include="Constant" MetadataName="RootComment" />
 
     <!-- Make sure we're always private to the referencing project. 
          Prevents analyzers from "flowing out" of the referencing project. -->


### PR DESCRIPTION
Since now most specific packages just extend and project @(Constant) items, they effectively are all "constants", and the comment on the root class used to be "Provides access project-defined constants.". This no longer is the case for the following:

- Metadata: exposes project-defined AssemblyMetadata, not "constants"
- AssemblyInfo: exposes [Assembly*] attributes
- Git: build-time source repo information, not even project constants
- Vsix: manifest values, again, not even project values.

We should therefore allow a new metadata beside the `Root` attribute we added to allow custom roots: `RootComment`. Since each constant is emitted as a standalone file, we would have duplication, but we want to keep this approach for performance reasons.

We default to the old comment if none is specified. Example of a custom constant with a custom root and its comment:

```xml
<Constant Include="Foo.Bar" Value="Baz" Comment="A Bar value" Root="." RootComment="All the foos!" />
```