### PR TITLE
Allow project properties to specify custom comment

### DIFF
--- a/src/ThisAssembly.Project/ThisAssembly.Project.targets
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.targets
@@ -24,7 +24,7 @@
     </ItemGroup>
     <ItemGroup>
       <!-- Collect requested properties, and eval their value -->
-      <Constant Include="@(ProjectPropertyDistinct -> 'Project.%(Identity)')" Value="$(%(ProjectPropertyDistinct.Identity))" Root="." />
+      <Constant Include="@(ProjectPropertyDistinct -> 'Project.%(Identity)')" Value="$(%(ProjectPropertyDistinct.Identity))" Comment="%(ProjectPropertyDistinct.Comment)" Root="." />
     </ItemGroup>
   </Target>
   

--- a/src/ThisAssembly.Project/readme.md
+++ b/src/ThisAssembly.Project/readme.md
@@ -11,7 +11,7 @@ them as `ProjectProperty` MSBuild items in the project file, such as:
   </PropertyGroup>
   <ItemGroup>
     <!-- Opt-in to emitting that property value as a constant in ThisAssembly.Project -->
-    <ProjectProperty Include="Foo" />
+    <ProjectProperty Include="Foo" Comment="This comment replaces the default comment :)" />
   </ItemGroup>
 ```
 

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -40,6 +40,13 @@ public record class Tests(ITestOutputHelper Output)
             """.ReplaceLineEndings(), ThisAssembly.Project.Multiline.ReplaceLineEndings());
 
     [Fact]
+    public void CanUseProjectFullFileContents()
+    {
+        Assert.NotEmpty(ThisAssembly.Project.ProjectFile);
+        Assert.False(ThisAssembly.Project.ProjectFile.StartsWith("|"));
+    }
+
+    [Fact]
     public void CanUseConstants()
         => Assert.Equal("Baz", ThisAssembly.Constants.Foo.Bar);
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -20,6 +20,7 @@
     <!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
     <NoWarn>CS0618;CS8981;TA100;$(NoWarn)</NoWarn>
     <PackageScribanIncludeSource>false</PackageScribanIncludeSource>
+    <ProjectFile>$([System.IO.File]::ReadAllText($(MSBuildProjectFullPath)))</ProjectFile>
   </PropertyGroup>
 
   <Import Project="..\*\ThisAssembly*.props" />
@@ -66,6 +67,7 @@
     <ProjectProperty Include="Foo" />
     <ProjectProperty Include="Description" />
     <ProjectProperty Include="Multiline" />
+    <ProjectProperty Include="ProjectFile" Comment="Full project contents" />
     <Constant Include="Foo.Raw" Value="$(Multiline)" Comment="$(Multiline)" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />
     <Constant Include="Foo.Hello" Value="World" Comment="Comments make everything better 😍" />


### PR DESCRIPTION
This can help workaround the issue of the value having invalid content for an XML summary element (i..e. the value has XML).

Further fixes #390