### PR TITLE
Properly emit AssemblyInfo even if GenerateAssemblyInfo=false

### DIFF
--- a/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.targets
+++ b/src/ThisAssembly.AssemblyInfo/ThisAssembly.AssemblyInfo.targets
@@ -10,6 +10,34 @@
     <FundingPackageId Include="ThisAssembly.AssemblyInfo" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(GenerateAssemblyInfo)' != 'true'">
+    <!-- The SDK will not set these attributes to 'true' unless GenerateAssemblyInfo=true, so we must override that 
+         in order for the attributes to be collected anyways. Since GenerateAssemblyInfo=false, the actual codegen 
+         will not happen, so this default value is safe as we only depend on GetAssemblyAttributes, which is not 
+         conditioned to GenerateAssemblyInfo
+         This is copied from https://github.com/dotnet/sdk/blob/main/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateAssemblyInfo.targets#L26-L44
+    -->
+    <GenerateAssemblyCompanyAttribute Condition="'$(GenerateAssemblyCompanyAttribute)' == ''">true</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyConfigurationAttribute Condition="'$(GenerateAssemblyConfigurationAttribute)' == ''">true</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCopyrightAttribute Condition="'$(GenerateAssemblyCopyrightAttribute)' == ''">true</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyDescriptionAttribute Condition="'$(GenerateAssemblyDescriptionAttribute)' == ''">true</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyFileVersionAttribute Condition="'$(GenerateAssemblyFileVersionAttribute)' == ''">true</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute Condition="'$(GenerateAssemblyInformationalVersionAttribute)' == ''">true</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyTrademarkAttribute Condition="'$(GenerateAssemblyTrademarkAttribute)' == ''">true</GenerateAssemblyTrademarkAttribute>
+    <GenerateAssemblyProductAttribute Condition="'$(GenerateAssemblyProductAttribute)' == ''">true</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyTitleAttribute Condition="'$(GenerateAssemblyTitleAttribute)' == ''">true</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyVersionAttribute Condition="'$(GenerateAssemblyVersionAttribute)' == ''">true</GenerateAssemblyVersionAttribute>
+    <GenerateRepositoryUrlAttribute Condition="'$(GenerateRepositoryUrlAttribute)' == '' and !('$(TargetFrameworkIdentifier)' == '.NETFramework' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 4.5)))">true</GenerateRepositoryUrlAttribute>
+    <GenerateNeutralResourcesLanguageAttribute Condition="'$(GenerateNeutralResourcesLanguageAttribute)' == ''">true</GenerateNeutralResourcesLanguageAttribute>
+    <GenerateAssemblyMetadataAttributes Condition="'$(GenerateAssemblyMetadataAttributes)' == ''">true</GenerateAssemblyMetadataAttributes>
+    <IncludeSourceRevisionInInformationalVersion Condition="'$(IncludeSourceRevisionInInformationalVersion)' == ''">true</IncludeSourceRevisionInInformationalVersion>
+    <GenerateInternalsVisibleToAttributes Condition="'$(GenerateInternalsVisibleToAttributes)' == ''">true</GenerateInternalsVisibleToAttributes>
+    <GenerateRequiresPreviewFeaturesAttribute Condition="'$(GenerateRequiresPreviewFeaturesAttribute)' == '' and '$(IsNetCoreAppTargetingLatestTFM)' == 'true'">true</GenerateRequiresPreviewFeaturesAttribute>
+    <GenerateTargetPlatformAttribute Condition="'$(GenerateTargetPlatformAttribute)' == ''">true</GenerateTargetPlatformAttribute>
+    <GenerateSupportedOSPlatformAttribute Condition="'$(GenerateSupportedOSPlatformAttribute)' == ''">true</GenerateSupportedOSPlatformAttribute>
+    <GenerateDisableRuntimeMarshallingAttribute Condition="'$(GenerateDisableRuntimeMarshallingAttribute)' == ''">true</GenerateDisableRuntimeMarshallingAttribute>
+  </PropertyGroup>
+
   <Target Name="PrepareAssemblyInfoConstants"
           BeforeTargets="PrepareConstants"
           DependsOnTargets="GetAssemblyAttributes">

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ThisAssemblyNamespace>ThisAssemblyTests</ThisAssemblyNamespace>
     <ThisAssemblyVisibility>public</ThisAssemblyVisibility>
+    <!-- Showcase we don't require the built-in assembly info generation --> 
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Multiline>
       A Description
       with a newline and


### PR DESCRIPTION
We were missing this since the SDK defaults the specific attributes to `true` only if the overall flag `GenerateAssemblyInfo` is `true`. We change that in our targets, but without forcing `GenerateAssemblyInfo=true`. This allows to turn off codegen, but still get the attributes as items.

Fixes #407