### PR TITLE
Since types can be public, ensure we always have XML comments

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -34,6 +34,9 @@
 {{~ end ~}}
 {{ end }}
 {{ func render }}
+    /// <summary>
+    /// {{ $0.Comment }}
+    /// </summary>
     public static partial class {{ $0.Name | string.replace "-" "_" | string.replace " " "_" }}
     {
         {{~ for value in $0.Values ~}}
@@ -73,8 +76,5 @@ namespace {{ Namespace }};
 /// </summary>
 {{ Visibility }}partial class ThisAssembly
 {
-    /// <summary>
-    /// {{ RootArea.Comment }}
-    /// </summary>
     {{ render RootArea }}
 }

--- a/src/ThisAssembly.Resources/CSharp.sbntxt
+++ b/src/ThisAssembly.Resources/CSharp.sbntxt
@@ -31,17 +31,31 @@
 		{
 			{{~ if $0.IsText ~}}
 			private static string text;
+
+            /// <summary>
+            /// Gets the resource as plain text.
+            /// </summary>
 			public static string Text => 
 				text ??= EmbeddedResource.GetContent(@"{{ $0.Path }}");
 			{{~ end ~}}
 
+            /// <summary>
+            /// Gets the resource as a byte array.
+            /// </summary>
 			public static byte[] GetBytes() => 
 				EmbeddedResource.GetBytes(@"{{ $0.Path }}");
+
+            /// <summary>
+            /// Gets the resource as a stream.
+            /// </summary>
 			public static Stream GetStream() =>
 				EmbeddedResource.GetStream(@"{{ $0.Path }}");
 		}
 {{ end }}
 {{ func render }}
+    /// <summary>
+    /// {{ $0.Comment }}
+    /// </summary>
 	public static partial class {{ $0.Name | string.replace "-" "_" | string.replace " " "_" }}
 	{
 		{{~ if $0.Resources ~}}
@@ -65,8 +79,5 @@ namespace {{ Namespace }};
 /// </summary>
 {{ Visibility }}partial class ThisAssembly
 {
-    /// <summary>
-    /// Provides access to assembly embedded resources.
-    /// </summary>
 	{{ render RootArea }}
 }

--- a/src/ThisAssembly.Resources/ResourcesGenerator.cs
+++ b/src/ThisAssembly.Resources/ResourcesGenerator.cs
@@ -42,7 +42,7 @@ public class ResourcesGenerator : IIncrementalGenerator
                 {
                     if (!p.GlobalOptions.TryGetValue("build_property.EmbeddedResourceStringExtensions", out var extensions) ||
                         extensions == null)
-                        return Array.Empty<string>();
+                        return [];
 
                     return extensions.Split('|');
                 })

--- a/src/ThisAssembly.Strings/CSharp.sbntxt
+++ b/src/ThisAssembly.Strings/CSharp.sbntxt
@@ -29,6 +29,7 @@
         {{~ end ~}}
 {{ end }}
 {{ func render }}
+    /// <summary />
     public static partial class {{ $0.Id }}
     {
         {{~ for value in $0.Values }}

--- a/src/ThisAssembly.Tests/Extensions.cs
+++ b/src/ThisAssembly.Tests/Extensions.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 
+/// <summary />
 public static class Extensions
 {
+    /// <summary />
     public static string ReplaceLineEndings(this string input) => ReplaceLineEndings(input, Environment.NewLine);
 
+    /// <summary />
     public static string ReplaceLineEndings(this string input, string replacementText)
     {
 #if NET6_0_OR_GREATER

--- a/src/ThisAssembly.Tests/ScribanTests.cs
+++ b/src/ThisAssembly.Tests/ScribanTests.cs
@@ -9,8 +9,10 @@ using Xunit.Abstractions;
 
 namespace ThisAssemblyTests;
 
+/// <summary />
 public class ScribanTests(ITestOutputHelper Console)
 {
+    /// <summary />
     [Fact]
     public void CanRenderModel()
     {

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -9,16 +9,20 @@ using Xunit.Abstractions;
 
 namespace ThisAssemblyTests;
 
+/// <summary />
 public record class Tests(ITestOutputHelper Output)
 {
+    /// <summary />
     [Fact]
     public void CanReadResourceFile()
         => Assert.NotNull(ResourceFile.Load("Resources.resx", "Strings"));
 
+    /// <summary />
     [Fact]
     public void CanUseInfo()
         => Assert.Equal("ThisAssembly.Tests", ThisAssembly.Info.Title);
 
+    /// <summary />
     [Fact]
     public void CanUseInfoDescription()
         => Assert.Equal(
@@ -29,6 +33,7 @@ public record class Tests(ITestOutputHelper Output)
                   // Some comments too.
             """.ReplaceLineEndings(), ThisAssembly.Info.Description.ReplaceLineEndings());
 
+    /// <summary />
     [Fact]
     public void CanUseMultilineProjectProperty()
         => Assert.Equal(
@@ -39,6 +44,7 @@ public record class Tests(ITestOutputHelper Output)
                   // Some comments too.
             """.ReplaceLineEndings(), ThisAssembly.Project.Multiline.ReplaceLineEndings());
 
+    /// <summary />
     [Fact]
     public void CanUseProjectFullFileContents()
     {
@@ -46,98 +52,122 @@ public record class Tests(ITestOutputHelper Output)
         Assert.False(ThisAssembly.Project.ProjectFile.StartsWith("|"));
     }
 
+    /// <summary />
     [Fact]
     public void CanUseConstants()
         => Assert.Equal("Baz", ThisAssembly.Constants.Foo.Bar);
 
+    /// <summary />
     [Fact]
     public void CanUseTypedIntConstant()
         => Assert.Equal(123, ThisAssembly.Constants.TypedInt);
 
+    /// <summary />
     [Fact]
     public void CanUseTypedInt64Constant()
         => Assert.Equal(123, ThisAssembly.Constants.TypedInt64);
 
+    /// <summary />
     [Fact]
     public void CanUseTypedLongConstant()
         => Assert.Equal(123, ThisAssembly.Constants.TypedLong);
 
+    /// <summary />
     [Fact]
     public void CanUseTypedBoolConstant()
         => Assert.True(ThisAssembly.Constants.TypedBoolean);
 
+    /// <summary />
     [Fact]
     public void CanUseTypedDoubleConstant()
         => Assert.Equal(1.23, ThisAssembly.Constants.TypedDouble);
 
+    /// <summary />
     [Fact]
     public void CanUseTypedTimeSpanStaticProp()
         => Assert.Equal(TimeSpan.FromSeconds(5), ThisAssembly.Constants.TypedTimeSpan);
 
+    /// <summary />
     [Fact]
     public void CanUseFileConstants()
         => Assert.Equal(ThisAssembly.Constants.Content.Docs.License, Path.Combine("Content", "Docs", "License.md"));
 
+    /// <summary />
     [Fact]
     public void CanUseFileConstantInvalidIdentifier()
         => Assert.Equal(ThisAssembly.Constants.Content.Docs._12._Readme_copy_, Path.Combine("Content", "Docs", "12. Readme (copy).txt"));
 
+    /// <summary />
     [Fact]
     public void CanUseFileConstantLinkedFile()
         => Assert.Equal(ThisAssembly.Constants.Included.Readme, Path.Combine("Included", "Readme.txt"));
 
+    /// <summary />
     [Fact]
     public void CanUseMetadata()
         => Assert.Equal("Bar", ThisAssembly.Metadata.Foo);
 
+    /// <summary />
     [Fact]
     public void CanUseHierarchicalMetadata()
         => Assert.Equal("Baz", ThisAssembly.Metadata.Root.Foo.Bar);
 
+    /// <summary />
     [Fact]
     public void CanUseProjectProperty()
         => Assert.Equal("Bar", ThisAssembly.Project.Foo);
 
+    /// <summary />
     [Fact]
     public void CanUseStringsNamedArguments()
         => Assert.NotNull(ThisAssembly.Strings.Named("hello", "world"));
 
+    /// <summary />
     [Fact]
     public void CanUseStringsIndexedArguments()
         => Assert.NotNull(ThisAssembly.Strings.Indexed("hello", "world"));
 
+    /// <summary />
     [Fact]
     public void CanUseStringsNamedFormattedArguments()
         => Assert.Equal("Year 2020, Month 03", ThisAssembly.Strings.WithNamedFormat(new DateTime(2020, 3, 20)));
 
+    /// <summary />
     [Fact]
     public void CanUseStringsIndexedFormattedArguments()
         => Assert.Equal("Year 2020, Month 03", ThisAssembly.Strings.WithIndexedFormat(new DateTime(2020, 3, 20)));
 
+    /// <summary />
     [Fact]
     public void CanUseStringResource()
         => Assert.Equal("Value", ThisAssembly.Strings.Foo.Bar.Baz);
 
+    /// <summary />
     [Fact]
     public void CanUseTextResource()
         => Assert.NotNull(ThisAssembly.Resources.Content.Styles.Custom.Text);
 
+    /// <summary />
     [Fact]
     public void CanUseByteResource()
         => Assert.NotNull(ThisAssembly.Resources.Content.Styles.Main.GetBytes());
 
+    /// <summary />
     [Fact]
     public void CanUseSameNameDifferentExtensions()
         => Assert.NotNull(ThisAssembly.Resources.Content.Swagger.swagger_ui.css.GetBytes());
 
+    /// <summary />
     [Fact]
     public void CanUseFileInvalidCharacters()
         => Assert.NotNull(ThisAssembly.Resources.webhook_data.Text);
 
+    /// <summary />
     [Fact]
     public void CanUseGitConstants()
         => Assert.NotEmpty(ThisAssembly.Git.Commit);
 
+    /// <summary />
     [Fact]
     public void CanUseGitBranchConstants()
     {
@@ -145,6 +175,7 @@ public record class Tests(ITestOutputHelper Output)
         Output.WriteLine(ThisAssembly.Git.Branch);
     }
 
+    /// <summary />
     [Fact]
     public void CanUseSemicolonsInConstant()
         => Assert.Equal("A;B;C", ThisAssembly.Constants.WithSemiColon);

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -19,10 +19,12 @@
       // Some comments too.</Description>
     <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">net472</TargetFramework>
     <RootNamespace>ThisAssemblyTests</RootNamespace>
-    <!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <NoWarn>CS0618;CS8981;TA100;$(NoWarn)</NoWarn>
     <PackageScribanIncludeSource>false</PackageScribanIncludeSource>
     <ProjectFile>$([System.IO.File]::ReadAllText($(MSBuildProjectFullPath)))</ProjectFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="..\*\ThisAssembly*.props" />
@@ -69,7 +71,7 @@
     <ProjectProperty Include="Foo" />
     <ProjectProperty Include="Description" />
     <ProjectProperty Include="Multiline" />
-    <ProjectProperty Include="ProjectFile" Comment="Full project contents" />
+    <ProjectProperty Include="ProjectFile" />
     <Constant Include="Foo.Raw" Value="$(Multiline)" Comment="$(Multiline)" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />
     <Constant Include="Foo.Hello" Value="World" Comment="Comments make everything better 😍" />


### PR DESCRIPTION
This is important in particular when we add intermediate automatic "area" classes (such as when a constant is Foo.Bar.Baz), since in those cases, the user has no way of specifying a comment to fix the issue.