### PR TITLE
Make sure we escape constants XML comments

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -13,7 +13,7 @@
         {{~ if $0.Comment ~}}
         {{ $0.Comment }}
         {{~ else ~}}
-	    /// => @"{{ $0.Value }}"
+	    /// => @"{{ $0.EscapedValue }}"
         {{~ end ~}}
 	    /// </summary>
 {{- end -}}

--- a/src/ThisAssembly.Constants/ConstantsGenerator.cs
+++ b/src/ThisAssembly.Constants/ConstantsGenerator.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 using Devlooped.Sponsors;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -93,9 +94,9 @@ public class ConstantsGenerator : IIncrementalGenerator
         }
 
         if (comment != null)
-            comment = "/// " + string.Join(Environment.NewLine + "/// ", comment.Trim().Replace("\\n", Environment.NewLine).Trim(['\r', '\n']).Split([Environment.NewLine], StringSplitOptions.None));
+            comment = "/// " + string.Join(Environment.NewLine + "/// ", new XText(comment).ToString().Trim().Replace("\\n", Environment.NewLine).Trim(['\r', '\n']).Split([Environment.NewLine], StringSplitOptions.None));
         else
-            comment = "/// " + string.Join(Environment.NewLine + "/// ", value.Replace("\\n", Environment.NewLine).Trim(['\r', '\n']).Split([Environment.NewLine], StringSplitOptions.None));
+            comment = "/// " + string.Join(Environment.NewLine + "/// ", new XText(value).ToString().Replace("\\n", Environment.NewLine).Trim(['\r', '\n']).Split([Environment.NewLine], StringSplitOptions.None));
 
         // Revert normalization of newlines performed in MSBuild to workaround the limitation in editorconfig.
         var rootArea = Area.Load([new(name, value.Replace("\\n", Environment.NewLine).Trim(['\r', '\n']), comment, type ?? "string"),], root, rootComment);

--- a/src/ThisAssembly.Constants/Model.cs
+++ b/src/ThisAssembly.Constants/Model.cs
@@ -125,5 +125,6 @@ record Area(string Name, string Prefix)
 [DebuggerDisplay("{Name} = {Value}")]
 record Constant(string Name, string? Value, string? Comment, string Type = "string")
 {
+    public string? EscapedValue => Value == null ? null : new XText(Value).ToString();
     public bool IsText => Type.Equals("string", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -23,6 +23,7 @@
     <NoWarn>CS0618;CS8981;TA100;$(NoWarn)</NoWarn>
     <PackageScribanIncludeSource>false</PackageScribanIncludeSource>
     <ProjectFile>$([System.IO.File]::ReadAllText($(MSBuildProjectFullPath)))</ProjectFile>
+    <ProjectFileComment>$(ProjectFile)</ProjectFileComment>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
@@ -71,6 +72,7 @@
     <ProjectProperty Include="Foo" />
     <ProjectProperty Include="Description" />
     <ProjectProperty Include="Multiline" />
+    <ProjectProperty Include="ProjectFileComment" Comment="Full project contents" />
     <ProjectProperty Include="ProjectFile" />
     <Constant Include="Foo.Raw" Value="$(Multiline)" Comment="$(Multiline)" />
     <Constant Include="Foo.Bar" Value="Baz" Comment="Yay!" />


### PR DESCRIPTION
This ensures we get valid XML doc comments, rather than potentially nested (invalid) XML if the property happens to contain XML.

Additional fix for #408 