### PR TITLE
Make sure project properties initialize after source control

### DIFF
--- a/src/ThisAssembly.Project/ThisAssembly.Project.targets
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.targets
@@ -13,12 +13,14 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <InjectThisAssemblyProjectDependsOn Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">
+    <!-- Backwards compability for original property name -->
+    <PrepareProjectPropertiesDependsOn>$(InjectThisAssemblyProjectDependsOn)</PrepareProjectPropertiesDependsOn>
+    <PrepareProjectPropertiesDependsOn Condition="'$(SourceControlInformationFeatureSupported)' == 'true'">
       InitializeSourceControlInformation
-    </InjectThisAssemblyProjectDependsOn>
+    </PrepareProjectPropertiesDependsOn>
   </PropertyGroup>
 
-  <Target Name="PrepareProjectProperties" BeforeTargets="PrepareConstants">
+  <Target Name="PrepareProjectProperties" BeforeTargets="PrepareConstants" DependsOnTargets="$(PrepareProjectPropertiesDependsOn)">
     <ItemGroup>
       <ProjectPropertyDistinct Include="@(ProjectProperty -> Distinct())" />
     </ItemGroup>

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -54,6 +54,13 @@ public record class Tests(ITestOutputHelper Output)
 
     /// <summary />
     [Fact]
+    public void CanUseProjectRepositoryUrl()
+    {
+        Assert.NotEmpty(ThisAssembly.Project.RepositoryUrl);
+    }
+
+    /// <summary />
+    [Fact]
     public void CanUseConstants()
         => Assert.Equal("Baz", ThisAssembly.Constants.Foo.Bar);
 


### PR DESCRIPTION
If source control information is supported, make sure we automatically take a dependency on InitializeSourceControlInformation.

We take the chance to also rename the old property `InjectThisAssemblyProjectDependsOn` to `PrepareProjectPropertiesDependsOn` which aligns better with the new target.