### PR TITLE
Add RuntimeIdentifer(s) properties to project constants

### DIFF
--- a/src/ThisAssembly.Project/ThisAssembly.Project.props
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.props
@@ -7,6 +7,9 @@
     <ProjectProperty Include="TargetFrameworkIdentifier" />
     <ProjectProperty Include="TargetFrameworkMoniker" />
     <ProjectProperty Include="TargetFrameworkVersion" />
+
+    <ProjectProperty Include="RuntimeIdentifier" />
+    <ProjectProperty Include="RuntimeIdentifiers" />
   </ItemGroup>
 
 </Project>

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -126,6 +126,11 @@ public record class Tests(ITestOutputHelper Output)
 
     /// <summary />
     [Fact]
+    public void CanUseProjectProperty2()
+        => Assert.NotEmpty(ThisAssembly.Project.RuntimeIdentifiers);
+
+    /// <summary />
+    [Fact]
     public void CanUseStringsNamedArguments()
         => Assert.NotNull(ThisAssembly.Strings.Named("hello", "world"));
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -26,6 +26,7 @@
     <ProjectFileComment>$(ProjectFile)</ProjectFileComment>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>true</WarningsAsErrors>
+    <RuntimeIdentifiers>win-x64;linux-x86</RuntimeIdentifiers>
   </PropertyGroup>
 
   <Import Project="..\*\ThisAssembly*.props" />


### PR DESCRIPTION
These are typically useful in addition to TFM.