### PR TITLE
Ensure we properly format multiline raw strings

### DIFF
--- a/src/ThisAssembly.Constants/CSharp.sbntxt
+++ b/src/ThisAssembly.Constants/CSharp.sbntxt
@@ -45,7 +45,6 @@
         {{ obsolete }}
         {{~ if RawStrings && value.IsText ~}}
 	    public {{ Modifier }} string {{ value.Name | string.replace "-" "_" | string.replace " " "_" }} ={{ Lambda }} 
-
 """
 {{ value.Value }}
 """;

--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.targets
@@ -50,8 +50,8 @@
     <ItemGroup>
       <!-- Normalize newlines to avoid losing content -->
       <Constant Update="@(Constant)">
-        <Value>$([MSBuild]::ValueOrDefault('%(Constant.Value)', '').Replace($([System.Environment]::NewLine), '\n'))</Value>
-        <Comment>$([MSBuild]::ValueOrDefault('%(Constant.Comment)', '').Replace($([System.Environment]::NewLine), '\n'))</Comment>
+        <Value>$([MSBuild]::ValueOrDefault('%(Constant.Value)', '').Replace('&#xD;&#xA;', '`n').Replace('&#xA;', '`n'))</Value>
+        <Comment>$([MSBuild]::ValueOrDefault('%(Constant.Comment)', '').Replace('&#xD;&#xA;', '`n').Replace('&#xA;', '`n'))</Comment>
       </Constant>
     </ItemGroup>
   </Target>

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 using Xunit.Abstractions;
 //using ThisAssembly = ThisAssemblyTests
@@ -191,4 +192,8 @@ public record class Tests(ITestOutputHelper Output)
     [Fact]
     public void CanUseSemicolonsInConstant()
         => Assert.Equal("A;B;C", ThisAssembly.Constants.WithSemiColon);
+
+    /// <summary />
+    [Fact]
+    public void CanReadJsonConstant() => JsonWebKey.Create(ThisAssembly.Metadata.Funding.GitHub.devlooped);
 }

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -119,4 +119,18 @@
     <CompilerVisibleProperty Include="ThisAssembly" />
   </ItemGroup>
 
+  <Target Name="DownloadDevloopedJwk" BeforeTargets="GetAssemblyAttributes" Inputs="$(MSBuildProjectFullPath)" Outputs="$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)devlooped.jwk">
+    <Exec Command="curl --silent --output $(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)devlooped.jwk https://sponsorlink.devlooped.com/jwk" />
+  </Target>
+
+  <Target Name="ReadDevloopedJwk" DependsOnTargets="DownloadDevloopedJwk" BeforeTargets="GetAssemblyAttributes">
+    <PropertyGroup>
+      <!-- Read public key we validate manifests against -->
+      <DevloopedJwk>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)devlooped.jwk'))</DevloopedJwk>
+    </PropertyGroup>
+    <ItemGroup>
+      <AssemblyMetadata Include="Funding.GitHub.devlooped" Value="$(DevloopedJwk.Trim())" />
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
We had weird newline formatting after applying C# whitespace normalization. A quick rewriter fixes that now.

We use the devlooped JWT which requies preserving formatting for proper parsing as a test.