### PR TITLE
Revert "Bump System.Threading.Tasks.Extensions in the system group"

### DIFF
--- a/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
+++ b/src/ThisAssembly.Constants/ThisAssembly.Constants.csproj
@@ -47,7 +47,7 @@ C#:
 
     <PackageReference Include="Scriban" Version="6.2.1" Pack="false" IncludeAssets="build" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />

--- a/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
+++ b/src/ThisAssembly.Resources/ThisAssembly.Resources.csproj
@@ -23,7 +23,7 @@
 
     <PackageReference Include="Scriban" Version="6.2.1" Pack="false" IncludeAssets="build" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />

--- a/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
+++ b/src/ThisAssembly.Strings/ThisAssembly.Strings.csproj
@@ -28,7 +28,7 @@ such as "Hello {name}".
 
     <PackageReference Include="Scriban" Version="6.2.1" Pack="false" IncludeAssets="build" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" Pack="false" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />


### PR DESCRIPTION
This reverts commit a6769ec857838f19955b9443e4b1a1bea6bcbd40.

Using a newer Tasks.Extensions can cause downstream failures, see https://github.com/devlooped/nugetizer/pull/660