### PR TITLE
Allow opting into ThisAssembly.Project via the ProjectProperty MSBuild property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -269,6 +269,15 @@ them as `ProjectProperty` MSBuild items in the project file, such as:
   </ItemGroup>
 ```
 
+The same opt-in can be the `ProjectProperty` MSBuild property instead of items. Its value is 
+included as-is as `@(ProjectProperty)` items, so semicolon-separated names work. This is the 
+path for [file-based apps](https://learn.microsoft.com/dotnet/core/sdk/file-based-apps):
+
+```csharp
+#:package ThisAssembly.Project
+#:property ProjectProperty=MSBuildProjectDirectory
+```
+
 ![](https://raw.githubusercontent.com/devlooped/ThisAssembly/main/img/ThisAssembly.Project.png)
 
 <!-- #project -->

--- a/src/ThisAssembly.Project/ThisAssembly.Project.csproj
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.csproj
@@ -22,6 +22,10 @@ them as `ProjectProperty` MSBuild items in project file, such as:
       &lt;ProjectProperty Include="Foo" /&gt;
     &lt;/ItemGroup&gt;
 
+Or via the ProjectProperty MSBuild property (included as-is as items), which file-based apps can set with:
+
+    #:property ProjectProperty=MSBuildProjectDirectory
+
 A corresponding `ThisAssembly.Project.Foo` constant with the value `Bar` is provided. 
 
 Generated code:

--- a/src/ThisAssembly.Project/ThisAssembly.Project.targets
+++ b/src/ThisAssembly.Project/ThisAssembly.Project.targets
@@ -23,6 +23,8 @@
 
   <Target Name="PrepareProjectProperties" BeforeTargets="PrepareConstants" DependsOnTargets="$(PrepareProjectPropertiesDependsOn)">
     <ItemGroup>
+      <!-- File-based apps can pass #:property ProjectProperty=Name;Other -->
+      <ProjectProperty Include="$(ProjectProperty)" Condition="'$(ProjectProperty)' != ''" />
       <ProjectPropertyDistinct Include="@(ProjectProperty -> Distinct())" />
     </ItemGroup>
     <ItemGroup>

--- a/src/ThisAssembly.Project/readme.md
+++ b/src/ThisAssembly.Project/readme.md
@@ -16,6 +16,15 @@ them as `ProjectProperty` MSBuild items in the project file, such as:
   </ItemGroup>
 ```
 
+The same opt-in can be the `ProjectProperty` MSBuild property instead of items. Its value is 
+included as-is as `@(ProjectProperty)` items, so semicolon-separated names work. This is the 
+path for [file-based apps](https://learn.microsoft.com/dotnet/core/sdk/file-based-apps):
+
+```csharp
+#:package ThisAssembly.Project
+#:property ProjectProperty=MSBuildProjectDirectory
+```
+
 ![](https://raw.githubusercontent.com/devlooped/ThisAssembly/main/img/ThisAssembly.Project.png)
 
 <!-- #project -->

--- a/src/ThisAssembly.Tests/Tests.cs
+++ b/src/ThisAssembly.Tests/Tests.cs
@@ -126,6 +126,14 @@ public record class Tests(ITestOutputHelper Output)
 
     /// <summary />
     [Fact]
+    public void CanUseProjectPropertyFromProperty()
+    {
+        Assert.Equal("from-property", ThisAssembly.Project.FromProjectProperty);
+        Assert.Equal("also-from-property", ThisAssembly.Project.AlsoFromProjectProperty);
+    }
+
+    /// <summary />
+    [Fact]
     public void CanUseProjectProperty2()
         => Assert.NotEmpty(ThisAssembly.Project.RuntimeIdentifiers);
 

--- a/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
+++ b/src/ThisAssembly.Tests/ThisAssembly.Tests.csproj
@@ -67,6 +67,9 @@
 
   <PropertyGroup>
     <Foo>Bar</Foo>
+    <FromProjectProperty>from-property</FromProjectProperty>
+    <AlsoFromProjectProperty>also-from-property</AlsoFromProjectProperty>
+    <ProjectProperty>FromProjectProperty;AlsoFromProjectProperty</ProjectProperty>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
File-based apps can set MSBuild properties with `#:property`, but they cannot declare `ProjectProperty` items. `ThisAssembly.Project` only emitted constants for those items, so `ThisAssembly.Project.MSBuildProjectDirectory` failed to compile from an Aspire/file-based AppHost.

`PrepareProjectProperties` now includes `$(ProjectProperty)` as-is as `@(ProjectProperty)` items. Semicolon-separated names work the same as an item `Include`. File-based usage:

```csharp
#:package ThisAssembly.Project
#:property ProjectProperty=MSBuildProjectDirectory
```

Existing item-based opt-in is unchanged. Tests cover the property path with a semicolon-separated list.