### PR TITLE
Resolve Git branch from worktree gitdir pointers

### DIFF
--- a/src/ThisAssembly.Git/ThisAssembly.Git.targets
+++ b/src/ThisAssembly.Git/ThisAssembly.Git.targets
@@ -72,12 +72,21 @@
     <Warning Code="TA001" Text="A valid SourceLink provider does not seem to be installed for the current repository/project. Some values may be empty." Condition="'$(SourceLinkUrl)' == ''" />
     
     <PropertyGroup Condition="'$(RepositoryBranch)' == '' and '$(RepositoryRoot)' != ''">
-      <!-- If we didnd't populate from CI/ENV, we can still use the source control provider itself to get the branch name -->
+      <!-- If we didn't populate from CI/ENV, we can still use the source control provider itself to get the branch name -->
       <_ThisAssemblyGitBranchName>@(_ThisAssemblyGitSourceRoot -> '%(BranchName)')</_ThisAssemblyGitBranchName>
       <!-- The above only works on .NET SDK 9.0+, so account for 8.0 implicit nuget package -->
 
-      <_ThisAssemblyGitBranchName Condition="'$(_ThisAssemblyGitBranchName)' == ''">$([System.IO.File]::ReadAllText('$(RepositoryRoot).git/HEAD').Trim())</_ThisAssemblyGitBranchName>
-      <RepositoryBranch>$(_ThisAssemblyGitBranchName.TrimStart("ref:").Trim().Replace('refs/heads/', '').Replace('refs/tags/', ''))</RepositoryBranch>
+      <!-- Regular checkout: .git is a directory containing HEAD -->
+      <_ThisAssemblyGitHead Condition="'$(_ThisAssemblyGitBranchName)' == '' and Exists('$(RepositoryRoot).git/HEAD')">$(RepositoryRoot).git/HEAD</_ThisAssemblyGitHead>
+
+      <!-- Worktree / separate-git-dir / submodule: .git is a file with 'gitdir: &lt;path&gt;' -->
+      <_ThisAssemblyGitFile Condition="'$(_ThisAssemblyGitHead)' == '' and '$(_ThisAssemblyGitBranchName)' == '' and $([System.IO.File]::Exists('$(RepositoryRoot).git'))">$([System.IO.File]::ReadAllText('$(RepositoryRoot).git').Trim())</_ThisAssemblyGitFile>
+      <_ThisAssemblyGitDir Condition="'$(_ThisAssemblyGitFile)' != '' and $(_ThisAssemblyGitFile.StartsWith('gitdir:', StringComparison.OrdinalIgnoreCase))">$(_ThisAssemblyGitFile.Substring(7).Trim())</_ThisAssemblyGitDir>
+      <_ThisAssemblyGitDir Condition="'$(_ThisAssemblyGitDir)' != ''">$([MSBuild]::NormalizePath('$(RepositoryRoot)', '$(_ThisAssemblyGitDir)'))</_ThisAssemblyGitDir>
+      <_ThisAssemblyGitHead Condition="'$(_ThisAssemblyGitHead)' == '' and '$(_ThisAssemblyGitDir)' != '' and Exists('$(_ThisAssemblyGitDir)/HEAD')">$(_ThisAssemblyGitDir)/HEAD</_ThisAssemblyGitHead>
+
+      <_ThisAssemblyGitBranchName Condition="'$(_ThisAssemblyGitBranchName)' == '' and '$(_ThisAssemblyGitHead)' != ''">$([System.IO.File]::ReadAllText('$(_ThisAssemblyGitHead)').Trim())</_ThisAssemblyGitBranchName>
+      <RepositoryBranch Condition="'$(_ThisAssemblyGitBranchName)' != ''">$(_ThisAssemblyGitBranchName.TrimStart("ref:").Trim().Replace('refs/heads/', '').Replace('refs/tags/', ''))</RepositoryBranch>
     </PropertyGroup>
 
   </Target>

--- a/src/ThisAssembly.Tests/GitTests.cs
+++ b/src/ThisAssembly.Tests/GitTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ThisAssemblyTests;
+
+/// <summary>
+/// Exercises the <c>InitializeGitInformation</c> fallback that reads HEAD when
+/// SourceLink does not provide <c>BranchName</c> (typical on .NET SDK 8).
+/// </summary>
+public record class GitTests(ITestOutputHelper Output)
+{
+    /// <summary />
+    [Fact]
+    public void ReadsBranchFromGitDirectory()
+    {
+        using var dir = new TempDirectory();
+        var repo = Path.Combine(dir.Path, "repo");
+        Directory.CreateDirectory(Path.Combine(repo, ".git"));
+        File.WriteAllText(Path.Combine(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+
+        Assert.Equal("main", EvaluateBranch(repo));
+    }
+
+    /// <summary />
+    [Fact]
+    public void ReadsBranchFromWorktreeGitDirFileWithRelativePath()
+    {
+        using var dir = new TempDirectory();
+        var main = Path.Combine(dir.Path, "main");
+        var worktree = Path.Combine(dir.Path, "worktree");
+        var gitDir = Path.Combine(main, ".git", "worktrees", "worktree");
+
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(worktree);
+        File.WriteAllText(Path.Combine(gitDir, "HEAD"), "ref: refs/heads/feature/worktree\n");
+
+        var relativeGitDir = Path.GetRelativePath(worktree, gitDir).Replace('\\', '/');
+        File.WriteAllText(Path.Combine(worktree, ".git"), $"gitdir: {relativeGitDir}\n");
+
+        Assert.Equal("feature/worktree", EvaluateBranch(worktree));
+    }
+
+    /// <summary />
+    [Fact]
+    public void ReadsBranchFromWorktreeGitDirFileWithAbsolutePath()
+    {
+        using var dir = new TempDirectory();
+        var main = Path.Combine(dir.Path, "main");
+        var worktree = Path.Combine(dir.Path, "worktree");
+        var gitDir = Path.Combine(main, ".git", "worktrees", "worktree");
+
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(worktree);
+        File.WriteAllText(Path.Combine(gitDir, "HEAD"), "ref: refs/heads/reproduce-thisassembly-worktree\n");
+
+        var absoluteGitDir = gitDir.Replace('\\', '/');
+        File.WriteAllText(Path.Combine(worktree, ".git"), $"gitdir: {absoluteGitDir}\n");
+
+        Assert.Equal("reproduce-thisassembly-worktree", EvaluateBranch(worktree));
+    }
+
+    /// <summary />
+    [Fact]
+    public void DoesNotFailWhenGitHeadIsMissing()
+    {
+        using var dir = new TempDirectory();
+        var repo = Path.Combine(dir.Path, "repo");
+        Directory.CreateDirectory(repo);
+
+        Assert.Equal("", EvaluateBranch(repo));
+    }
+
+    string EvaluateBranch(string repositoryRoot)
+    {
+        var targetsPath = Path.GetFullPath(Path.Combine(ThisAssembly.Git.Root, "src", "ThisAssembly.Git", "ThisAssembly.Git.targets"));
+        Assert.True(File.Exists(targetsPath), $"Could not find ThisAssembly.Git.targets at {targetsPath}");
+
+        var evalDir = Path.Combine(Path.GetTempPath(), "ThisAssemblyGitEval", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(evalDir);
+        try
+        {
+            var projectPath = Path.Combine(evalDir, "git.proj");
+            var outputPath = Path.Combine(evalDir, "branch.txt");
+            var root = repositoryRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+
+            File.WriteAllText(projectPath, $$"""
+                <Project>
+                  <Target Name="InitializeSourceControlInformation" />
+                  <Import Project="{{Xml(targetsPath)}}" />
+                  <!-- Force the .git/HEAD fallback, as if CI/SourceLink did not populate the branch. -->
+                  <PropertyGroup>
+                    <RepositoryBranch></RepositoryBranch>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <SourceRoot Include="{{Xml(root)}}">
+                      <SourceControl>git</SourceControl>
+                    </SourceRoot>
+                  </ItemGroup>
+                  <Target Name="WriteBranch" DependsOnTargets="InitializeGitInformation">
+                    <WriteLinesToFile File="{{Xml(outputPath)}}" Lines="$(RepositoryBranch)" Overwrite="true" />
+                  </Target>
+                </Project>
+                """);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                Arguments = $"msbuild \"{projectPath}\" -nologo -v:m -t:WriteBranch",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = evalDir,
+            };
+
+            using var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start dotnet msbuild.");
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Output.WriteLine(stdout);
+            if (!string.IsNullOrWhiteSpace(stderr))
+                Output.WriteLine(stderr);
+
+            if (process.ExitCode != 0)
+                throw new InvalidOperationException($"msbuild failed ({process.ExitCode}):{Environment.NewLine}{stdout}{stderr}");
+
+            return File.Exists(outputPath) ? File.ReadAllText(outputPath).Trim() : "";
+        }
+        finally
+        {
+            try { Directory.Delete(evalDir, recursive: true); } catch { }
+        }
+    }
+
+    static string Xml(string value) => value
+        .Replace("&", "&amp;")
+        .Replace("\"", "&quot;")
+        .Replace("'", "&apos;")
+        .Replace("<", "&lt;")
+        .Replace(">", "&gt;");
+
+    sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ThisAssemblyGitTests", Guid.NewGuid().ToString("N"));
+
+        public TempDirectory() => Directory.CreateDirectory(Path);
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #506

`ThisAssembly.Git` assumed `.git` was a directory and always read `.git/HEAD`. In a linked worktree, `.git` is a `gitdir:` pointer file, so the SDK 8 fallback threw MSB4184 and the build failed.

The fallback now:

- reads `HEAD` from a normal `.git` directory
- follows `gitdir:` pointers (worktrees, `--separate-git-dir`, submodules), relative or absolute
- skips the fallback instead of failing when `HEAD` is missing
